### PR TITLE
Ff7tk next

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -221,7 +221,7 @@ jobs:
             apt-get update -y > /dev/null
             apt-get install -qqq ${{env.debianRequirments}} > /dev/null
             curl -s https://api.github.com/repos/sithlord48/ff7tk/releases/latest | awk -F\" '/browser_download_url.*_${{matrix.config.debArch}}*[.deb]/{print $(NF-1)}' | wget -i -
-            apt -y -qqq install ./libff7tk*.deb
+            apt -y install ./libff7tk*.deb
             rm libff7tk*.deb
           run: |
             git config --global --add safe.directory /home/runner/work/blackchocobo/blackchocobo

--- a/deploy/generate_ds_store.applescript
+++ b/deploy/generate_ds_store.applescript
@@ -36,7 +36,7 @@ on run argv
         set toolbar visible to false
         set the bounds to { 400, 100, 1200, 725 }
         set position of item "Black_Chocobo.app" to { 0, 325 }
-        set position of item "Applications" to { 510, 325 }
+        set position of item "Applications" to { 625, 325 }
       end tell
     close
   end tell

--- a/lang/bchoco_de.ts
+++ b/lang/bchoco_de.ts
@@ -1580,6 +1580,12 @@ Trigger, Tutorial zeigt</translation>
         <source>Item Editor - Always Cap Quantity to 99</source>
         <translation type="unfinished">Artikeleditor - Beschränken Sie die Menge immer auf 99</translation>
     </message>
+    <message>
+        <source>Change Widget Style
+ Fusion is recommended Other themes may not obey the color palette or contain graphical issues.</source>
+        <translation type="unfinished">Ändern Sie den Widget-Stil
+ Fusion wird empfohlen. Andere Themen entsprechen möglicherweise nicht der Farbpalette oder weisen grafische Probleme auf.</translation>
+    </message>
 </context>
 <context>
     <name>PartyTab</name>

--- a/lang/bchoco_en.ts
+++ b/lang/bchoco_en.ts
@@ -1577,6 +1577,12 @@ trigger showing that tutorial</translation>
         <source>Item Editor - Always Cap Quantity to 99</source>
         <translation>Item Editor - Always Cap Quantity to 99</translation>
     </message>
+    <message>
+        <source>Change Widget Style
+ Fusion is recommended Other themes may not obey the color palette or contain graphical issues.</source>
+        <translation>Change Widget Style
+ Fusion is recommended Other themes may not obey the color palette or contain graphical issues.</translation>
+    </message>
 </context>
 <context>
     <name>PartyTab</name>

--- a/lang/bchoco_es.ts
+++ b/lang/bchoco_es.ts
@@ -1579,6 +1579,12 @@ trigger showing that tutorial</source>
         <source>Item Editor - Always Cap Quantity to 99</source>
         <translation type="unfinished">Editor de artículos - Siempre limita la cantidad a 99</translation>
     </message>
+    <message>
+        <source>Change Widget Style
+ Fusion is recommended Other themes may not obey the color palette or contain graphical issues.</source>
+        <translation type="unfinished">Cambiar el estilo del widget
+  Se recomienda Fusion. Es posible que otros temas no obedezcan a la paleta de colores o contengan problemas gráficos.</translation>
+    </message>
 </context>
 <context>
     <name>PartyTab</name>

--- a/lang/bchoco_fr.ts
+++ b/lang/bchoco_fr.ts
@@ -1581,6 +1581,12 @@ le tutoriel sera affiché directement</translation>
         <source>Item Editor - Always Cap Quantity to 99</source>
         <translation type="unfinished">Éditeur d&apos;articles - Toujours limiter la quantité à 99</translation>
     </message>
+    <message>
+        <source>Change Widget Style
+ Fusion is recommended Other themes may not obey the color palette or contain graphical issues.</source>
+        <translation type="unfinished">Changer le style des widgets
+  La fusion est recommandée D&apos;autres thèmes peuvent ne pas respecter la palette de couleurs ou contenir des problèmes graphiques.</translation>
+    </message>
 </context>
 <context>
     <name>PartyTab</name>

--- a/lang/bchoco_it.ts
+++ b/lang/bchoco_it.ts
@@ -1577,6 +1577,12 @@ Seleziona una posizione per salvare i file delle statistiche del personaggio</tr
         <source>Item Editor - Always Cap Quantity to 99</source>
         <translation type="unfinished">Editor articolo - Limita sempre la quantità a 99</translation>
     </message>
+    <message>
+        <source>Change Widget Style
+ Fusion is recommended Other themes may not obey the color palette or contain graphical issues.</source>
+        <translation type="unfinished">Cambia stile widget
+  Si consiglia Fusion Altri temi potrebbero non rispettare la tavolozza dei colori o contenere problemi grafici.</translation>
+    </message>
 </context>
 <context>
     <name>PartyTab</name>

--- a/lang/bchoco_ja.ts
+++ b/lang/bchoco_ja.ts
@@ -1571,6 +1571,12 @@ trigger showing that tutorial</source>
         <source>Item Editor - Always Cap Quantity to 99</source>
         <translation type="unfinished">アイテムエディタ-常に数量を99に制限します</translation>
     </message>
+    <message>
+        <source>Change Widget Style
+ Fusion is recommended Other themes may not obey the color palette or contain graphical issues.</source>
+        <translation type="unfinished">ウィジェットのスタイルを変更
+  Fusion をお勧めします。他のテーマは、カラー パレットに従わないか、グラフィックの問題を含んでいる可能性があります。</translation>
+    </message>
 </context>
 <context>
     <name>PartyTab</name>

--- a/lang/bchoco_pl.ts
+++ b/lang/bchoco_pl.ts
@@ -1575,6 +1575,12 @@ trigger showing that tutorial</source>
         <source>Item Editor - Always Cap Quantity to 99</source>
         <translation>Edytor przedmiotów - Zawsze ograniczaj ilość do 99</translation>
     </message>
+    <message>
+        <source>Change Widget Style
+ Fusion is recommended Other themes may not obey the color palette or contain graphical issues.</source>
+        <translation type="unfinished">Zmień styl widżetu
+  Zalecane jest Fusion Inne motywy mogą nie być zgodne z paletą kolorów lub zawierać problemy graficzne.</translation>
+    </message>
 </context>
 <context>
     <name>PartyTab</name>

--- a/lang/bchoco_re.ts
+++ b/lang/bchoco_re.ts
@@ -1577,6 +1577,12 @@ trigger showing that tutorial</translation>
         <source>Item Editor - Always Cap Quantity to 99</source>
         <translation>Item Editor - Always Cap Quantity to 99</translation>
     </message>
+    <message>
+        <source>Change Widget Style
+ Fusion is recommended Other themes may not obey the color palette or contain graphical issues.</source>
+        <translation>Change Widget Style
+ Fusion is recommended Other themes may not obey the color palette or contain graphical issues.</translation>
+    </message>
 </context>
 <context>
     <name>PartyTab</name>

--- a/src/bcsettings.cpp
+++ b/src/bcsettings.cpp
@@ -128,7 +128,7 @@ void BCSettings::restoreDefaultSettings()
     instance()->settings->setValue(SETTINGS::REGION, QStringLiteral("NTSC-U"));
     instance()->settings->setValue(SETTINGS::CUSTOMDEFAULTSAVE, false);
     instance()->settings->setValue(SETTINGS::AUTOGROWTH, true);
-    instance()->settings->setValue(SETTINGS::USENATIVEDIALOGS, false);
+    instance()->settings->setValue(SETTINGS::USENATIVEDIALOGS, true);
     instance()->settings->setValue(SETTINGS::COLORSCHEME, 0);
     instance()->settings->setValue(SETTINGS::APPSTYLE, QStringLiteral("Fusion"));
     instance()->settings->setValue(SETTINGS::ITEMCAP99, false);

--- a/src/blackchocobo.cpp
+++ b/src/blackchocobo.cpp
@@ -1721,7 +1721,7 @@ void BlackChocobo::tabWidget_currentChanged(int index)
         break;
 
     case 1://Item Tab
-        ff7ItemModel->setItems(ff7->items(s));
+        ff7ItemModel->resetItems(ff7->items(s));
         ui->sbGil->setValue(ff7->gil(s));
         ui->sbGp->setValue(ff7->gp(s));
         ui->sbRuns->setValue(ff7->runs(s));

--- a/src/dialogs/options.cpp
+++ b/src/dialogs/options.cpp
@@ -31,8 +31,6 @@ Options::Options(QWidget *parent) : QDialog(parent)
   , ui(new Ui::Options)
 {
     ui->setupUi(this);
-    connect(BCSettings::instance(), &BCSettings::settingsChanged, this, &Options::loadSettings);
-    initConnections();
     int fmh = fontMetrics().height();
     QSize iconSize(fmh, fmh);
     updateText();
@@ -70,6 +68,8 @@ Options::Options(QWidget *parent) : QDialog(parent)
     });
 
     loadSettings();
+    connect(BCSettings::instance(), &BCSettings::settingsChanged, this, &Options::loadSettings);
+    initConnections();
 
     if(parent) {
         move(parent->x() + ((parent->width() -  sizeHint().width()) / 2), parent->y() + ((parent->sizeHint().height() - sizeHint().height()) / 2));
@@ -199,6 +199,7 @@ void Options::updateText()
     ui->buttonBox->button(QDialogButtonBox::Reset)->setToolTip(tr("Reset values to stored settings"));
     ui->buttonBox->button(QDialogButtonBox::Apply)->setToolTip(tr("Close and save changes"));
     ui->buttonBox->button(QDialogButtonBox::Cancel)->setToolTip(tr("Close and forget changes"));
+    ui->comboAppStyle->setToolTip(tr("Fusion is the recommended theme \n Other themes may contain graphical issues."));
 }
 
 void Options::btn_set_save_pc_clicked()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -40,8 +40,19 @@ int main(int argc, char *argv[])
     Q_INIT_RESOURCE(icons);
 
     QApplication a(argc, argv);
-    //Start application init.
-    a.setStyle(QStyleFactory::create(BCSettings::value(SETTINGS::APPSTYLE, QVariant(QString(a.style()->objectName()))).toString()));
+#if defined(Q_OS_WIN)
+    if(BCSettings::value(SETTINGS::APPSTYLE).isNull()) {
+        BCSettings::setValue(SETTINGS::APPSTYLE, QStringLiteral("Fusion"));
+    }
+    QSettings settings(QStringLiteral("HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize"), QSettings::NativeFormat);
+    int theme = settings.value(QStringLiteral("AppsUseLightTheme"), 0).toInt() + 1;
+    BCSettings::setValue(SETTINGS::COLORSCHEME, theme);
+#elif defined(Q_OS_DARWIN)
+    if(BCSettings::value(SETTINGS::APPSTYLE).isNull()) {
+        BCSettings::setValue(SETTINGS::APPSTYLE, QStringLiteral("Fusion"));
+    }
+#endif
+    a.setStyle(QStyleFactory::create(BCSettings::value(SETTINGS::APPSTYLE, a.style()->name()).toString()));
     a.setPalette(BCSettings::paletteForSetting());
     a.setAttribute(Qt::AA_DontUseNativeDialogs, !BCSettings::value(SETTINGS::USENATIVEDIALOGS).toBool());
     a.setApplicationName("Black Chocobo");


### PR DESCRIPTION
 - Fix up palette on Windows 
 - adjust dmg placement for applications folder
 - use the model reset method to avoid a false modified flag with itemModel
 - Changes to default settings (existing setting will not be changed) 
     - appStyle defaults to Fusion on windows / mac os first run
     - useNativeDialogs is true by default now