### PR TITLE
Setting keys

### DIFF
--- a/src/bcsettings.cpp
+++ b/src/bcsettings.cpp
@@ -93,7 +93,7 @@ void BCSettings::setValue(const QString &setting, const QVariant &value)
     else
         instance()->settings->setValue(setting, value);
     instance()->settings->sync();
-    emit instance()->settingsChanged();
+    Q_EMIT instance()->settingsChanged();
 }
 
 QVariant BCSettings::value(const QString &setting, const QVariant &defaultValue)

--- a/src/dialogs/options.cpp
+++ b/src/dialogs/options.cpp
@@ -188,6 +188,11 @@ void Options::initConnections()
 
 void Options::updateText()
 {
+    // Setting the title causes a random crash with 6.8+
+    // Until its known why setting the title crashes don't do it on 6.8+
+#if QT_VERSION < QT_VERSION_CHECK(6, 8, 0)
+    setWindowTitle(tr("Options"));
+#endif
     ui->buttonBox->button(QDialogButtonBox::RestoreDefaults)->setToolTip(tr("Reset values to defaults"));
     ui->buttonBox->button(QDialogButtonBox::Reset)->setToolTip(tr("Reset values to stored settings"));
     ui->buttonBox->button(QDialogButtonBox::Apply)->setToolTip(tr("Close and save changes"));

--- a/src/dialogs/options.ui
+++ b/src/dialogs/options.ui
@@ -19,9 +19,6 @@
     <verstretch>0</verstretch>
    </sizepolicy>
   </property>
-  <property name="windowTitle">
-   <string>Options</string>
-  </property>
   <property name="windowIcon">
    <iconset theme="configure">
     <normaloff>.</normaloff>.</iconset>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -28,14 +28,15 @@ int main(int argc, char *argv[])
     Q_INIT_RESOURCE(icons);
 
     QApplication a(argc, argv);
-#if !defined (Q_OS_LINUX)
     if (BCSettings::value(SETTINGS::APPSTYLE).isNull())
         BCSettings::setValue(SETTINGS::APPSTYLE, QStringLiteral("Fusion"));
-#endif
+
 #if defined(Q_OS_WIN)
-    QSettings settings(QStringLiteral("HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize"), QSettings::NativeFormat);
-    int theme = settings.value(QStringLiteral("AppsUseLightTheme"), 0).toInt() + 1;
-    BCSettings::setValue(SETTINGS::COLORSCHEME, theme);
+    if (BCSettings::value(SETTINGS::COLORSCHEME).isNull()) {
+        QSettings settings(QStringLiteral("HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize"), QSettings::NativeFormat);
+        int theme = settings.value(QStringLiteral("AppsUseLightTheme"), 0).toInt() + 1;
+        BCSettings::setValue(SETTINGS::COLORSCHEME, theme);
+    }
 #endif
     a.setStyle(QStyleFactory::create(BCSettings::value(SETTINGS::APPSTYLE, a.style()->name()).toString()));
     a.setPalette(BCSettings::paletteForSetting());


### PR DESCRIPTION
 - Use Fusion style as the default for all if not otherwise set
 - Don't enforce the system color settings on windows if the user has set the value to something already.
 - fix #97 , just don't set the title if were on Qt 6.8 