### PR TITLE
Add utility category

### DIFF
--- a/deploy/io.github.sithlord48.blackchocobo.metainfo.xml
+++ b/deploy/io.github.sithlord48.blackchocobo.metainfo.xml
@@ -29,6 +29,7 @@
 	<provides> <id>io.github.sithlord48.blackchocobo.desktop</id> </provides>
 	<categories>
 		<category>Game</category>
+		<category>Utility</category>
 	</categories>
 	<keywords>
 		<keyword translate="no">PSX</keyword>


### PR DESCRIPTION
This will show the app under `Game Tools` on sites such as flathub