### PR TITLE
Split Chinese translation into zh_CN and zh_TW

### DIFF
--- a/translations/CMakeLists.txt
+++ b/translations/CMakeLists.txt
@@ -16,7 +16,8 @@ set ( blackchocobo_TRS
     blackchocobo_ja.ts
     blackchocobo_pl.ts
     blackchocobo_re.ts
-    blackchocobo_zh.ts
+    blackchocobo_zh_CN.ts
+    blackchocobo_zh_TW.ts
 )
 
 if(WIN32 OR APPLE)
@@ -33,7 +34,8 @@ if(WIN32 OR APPLE)
         ${ff7tk_I18N_PATH}/ff7tk_ja.qm
         ${ff7tk_I18N_PATH}/ff7tk_pl.qm
         ${ff7tk_I18N_PATH}/ff7tk_re.qm
-        ${ff7tk_I18N_PATH}/ff7tk_zh.qm
+        ${ff7tk_I18N_PATH}/ff7tk_zh_CN.qm
+        ${ff7tk_I18N_PATH}/ff7tk_zh_TW.qm
     )
 endif()
 
@@ -65,5 +67,6 @@ elseif(APPLE)
     install(FILES ${MAC_QT_LANG_PATH}/qtbase_it.qm DESTINATION ${MAC_LANG_PATH} RENAME qt_it.qm)
     install(FILES ${MAC_QT_LANG_PATH}/qtbase_ja.qm DESTINATION ${MAC_LANG_PATH} RENAME qt_ja.qm)
     install(FILES ${MAC_QT_LANG_PATH}/qtbase_pl.qm DESTINATION ${MAC_LANG_PATH} RENAME qt_pl.qm)
-    install(FILES ${MAC_QT_LANG_PATH}/qtbase_zh_CN.qm DESTINATION ${MAC_LANG_PATH} RENAME qt_zh.qm)
+    install(FILES ${MAC_QT_LANG_PATH}/qtbase_zh_CN.qm DESTINATION ${MAC_LANG_PATH} RENAME qt_zh_CN.qm)
+    install(FILES ${MAC_QT_LANG_PATH}/qtbase_zh_TW.qm DESTINATION ${MAC_LANG_PATH} RENAME qt_zh_TW.qm)
 endif()

--- a/translations/blackchocobo_zh.ts
+++ b/translations/blackchocobo_zh.ts
@@ -73,7 +73,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>About Black Chocobo</source>
-        <translation>关于黑陆行鸟</translation>
+        <translation>关于黑色陆行鸟</translation>
     </message>
     <message>
         <source>Translators</source>
@@ -89,7 +89,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Black Chocobo </source>
-        <translation>黑陆行鸟 </translation>
+        <translation>黑色陆行鸟 </translation>
     </message>
     <message>
         <source>ff7tk: %1</source>
@@ -152,15 +152,15 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>1st</source>
-        <translation>1st</translation>
+        <translation>第一名</translation>
     </message>
     <message>
         <source>2nd</source>
-        <translation>2nd</translation>
+        <translation>第二名</translation>
     </message>
     <message>
         <source>3rd</source>
-        <translation>3rd</translation>
+        <translation>第三名</translation>
     </message>
     <message>
         <source>Bin</source>
@@ -188,7 +188,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Sub</source>
-        <translation>Sub</translation>
+        <translation>潜水艇</translation>
     </message>
     <message>
         <source>X: </source>
@@ -333,19 +333,19 @@ them&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
     </message>
     <message>
         <source>Coaster Shooter High Scores</source>
-        <translation>过山车射击高分</translation>
+        <translation>过山车射击游戏最高分</translation>
     </message>
     <message>
         <source>New Game Plus Created - Using: %1</source>
-        <translation>新游戏+已创建 - 使用：%1</translation>
+        <translation>新存档+已创建 - 使用：%1</translation>
     </message>
     <message>
         <source>Black Chocobo</source>
-        <translation>黑陆行鸟</translation>
+        <translation>黑色陆行鸟</translation>
     </message>
     <message>
         <source>Black chocobo</source>
-        <translation>黑陆行鸟</translation>
+        <translation>黑色陆行鸟</translation>
     </message>
     <message>
         <source>Apply Selected Replay </source>
@@ -377,7 +377,7 @@ them&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
     </message>
     <message>
         <source>Turtle Paradise</source>
-        <translation>龟乐园</translation>
+        <translation>海龟天堂</translation>
     </message>
     <message>
         <source>Buggy / Highwind</source>
@@ -518,7 +518,7 @@ trigger showing that tutorial</source>
     </message>
     <message>
         <source>Have Won the Submarine Game</source>
-        <translation>已赢得潜艇游戏</translation>
+        <translation>已赢得潜水艇小游戏</translation>
     </message>
     <message>
         <source>Party leader</source>
@@ -566,7 +566,7 @@ trigger showing that tutorial</source>
     </message>
     <message>
         <source>Fort Condor</source>
-        <translation>科尔德堡</translation>
+        <translation>秃鹰堡垒</translation>
     </message>
     <message>
         <source>German (PAL)</source>
@@ -582,7 +582,7 @@ trigger showing that tutorial</source>
     </message>
     <message>
         <source>Talked to Wedge Twice</source>
-        <translation>已和威奇交谈两次</translation>
+        <translation>已和威吉交谈两次</translation>
     </message>
     <message>
         <source>Place &amp;Wild Chocobo</source>
@@ -674,7 +674,7 @@ Table Entries are Editable</source>
     </message>
     <message>
         <source>Special Battle Wins</source>
-        <translation>特殊战斗胜利</translation>
+        <translation>特殊战斗胜利次数</translation>
     </message>
     <message>
         <source>UK English (PAL)</source>
@@ -695,7 +695,7 @@ location.</source>
     </message>
     <message>
         <source>Tiny bronco</source>
-        <translation>迷你飞空艇</translation>
+        <translation>飞机</translation>
     </message>
     <message>
         <source>Cleared All Items</source>
@@ -787,7 +787,7 @@ Var And Scrolling Synced To Left Table</source>
     </message>
     <message>
         <source>New Game Created - Using: %1</source>
-        <translation>新游戏已创建 - 使用：%1</translation>
+        <translation>新存档已创建 - 使用：%1</translation>
     </message>
     <message>
         <source>Clear All Stolen Materia</source>
@@ -795,7 +795,7 @@ Var And Scrolling Synced To Left Table</source>
     </message>
     <message>
         <source>Place &amp;Tiny Bronco/Chocobo</source>
-        <translation>放置&amp;迷你飞空艇/陆行鸟</translation>
+        <translation>放置&amp;飞机/陆行鸟</translation>
     </message>
     <message>
         <source>All Materia Added!</source>
@@ -843,11 +843,11 @@ Var And Scrolling Synced To Left Table</source>
     </message>
     <message>
         <source>Tiny Bronco / Chocobo</source>
-        <translation>迷你飞空艇 / 陆行鸟</translation>
+        <translation>飞机 / 陆行鸟</translation>
     </message>
     <message>
         <source>Played piano during flashback</source>
-        <translation>闪回中弹奏了钢琴</translation>
+        <translation>回忆中弹奏了钢琴</translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Number of wins for the &amp;quot;Special Battle&amp;quot;. Mini-Game Reward is based on number of wins.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
@@ -997,7 +997,7 @@ Var And Scrolling Synced To Left Table</source>
     </message>
     <message>
         <source>G-Bike High Score</source>
-        <translation>G-Bike高分</translation>
+        <translation>G型摩托最高分</translation>
     </message>
     <message>
         <source>&amp;Reload</source>
@@ -1067,7 +1067,7 @@ Var And Scrolling Synced To Left Table</source>
     </message>
     <message>
         <source>&amp;New Game</source>
-        <translation>&amp;新游戏</translation>
+        <translation>&amp;新存档</translation>
     </message>
     <message>
         <source>Builtin Data</source>
@@ -1075,7 +1075,7 @@ Var And Scrolling Synced To Left Table</source>
     </message>
     <message>
         <source>Set Replay Mission below to set the game back to that mission. This will automatically set your save location and disc # as well as Quest Progression vars. DO NOT OVERWRITE YOUR CURRENT SAVE when using this feature; I cannot promise that you will be able to play from any replay until the end of the game, or that any given replay will work in your save. This feature is still under development.</source>
-        <translation>在下方设置重玩任务，将游戏恢复到该任务。这将自动设置你的存档位置、光盘号以及任务进度变量。使用此功能时，请勿覆盖你当前的存档；我无法保证你能够从任何重玩任务一直玩到游戏结束，或者任何给定的重玩任务都能在你的存档中正常工作。此功能仍在开发中。</translation>
+        <translation>在下方设置重玩任务，将游戏恢复到该任务。这将自动设置你的存档位置、光盘号以及任务进度变量。使用此功能时，请勿覆盖你当前的存档；我无法保证你能够从任何的重玩任务一直玩到游戏结束，或许所有的重玩任务都能在你的存档中正常工作。此功能仍在开发中。</translation>
     </message>
     <message>
         <source>&amp;Settings</source>
@@ -1147,7 +1147,7 @@ Var And Scrolling Synced To Left Table</source>
     </message>
     <message>
         <source>Cloud&apos;s Flashback</source>
-        <translation>克劳德的闪回</translation>
+        <translation>克劳德的回忆</translation>
     </message>
     <message>
         <source>Set To Reactor 5 Mode</source>
@@ -1191,7 +1191,7 @@ Var And Scrolling Synced To Left Table</source>
     </message>
     <message>
         <source>Save Point Location In North Crater</source>
-        <translation>北之大空洞存档点位置</translation>
+        <translation>大空洞存档点位置</translation>
     </message>
     <message>
         <source>Trigger Game Over (countdown reached 0)</source>
@@ -1235,7 +1235,7 @@ Var And Scrolling Synced To Left Table</source>
     </message>
     <message>
         <source>Highwind</source>
-        <translation>高风</translation>
+        <translation>飞空艇</translation>
     </message>
     <message>
         <source>Tutorials Seen</source>
@@ -1247,7 +1247,7 @@ Var And Scrolling Synced To Left Table</source>
     </message>
     <message>
         <source>Diamond / Ultimate / Ruby  Weapon</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">钻石/究极/红宝石 武器</translation>
     </message>
     <message>
         <source>Disc  #</source>
@@ -1319,7 +1319,7 @@ Var And Scrolling Synced To Left Table</source>
     </message>
     <message>
         <source>Turtle Paradise Flyers Collected</source>
-        <translation>已收集的龟乐园传单</translation>
+        <translation>已收集的海龟天堂传单</translation>
     </message>
     <message>
         <source>Letter to a Daughter</source>
@@ -1327,7 +1327,7 @@ Var And Scrolling Synced To Left Table</source>
     </message>
     <message>
         <source>Search for &quot;Turtle Paradise&quot; using item search mode on the location tab</source>
-        <translation>在位置标签页使用物品搜索模式搜索“龟乐园”</translation>
+        <translation>在位置标签页使用物品搜索模式搜索“海龟天堂”</translation>
     </message>
 </context>
 <context>
@@ -1341,7 +1341,7 @@ Var And Scrolling Synced To Left Table</source>
     <name>Options</name>
     <message>
         <source>Save</source>
-        <translation>保存</translation>
+        <translation>存档</translation>
     </message>
     <message>
         <source>CharEditor - Simulate Leveling Up / Down</source>
@@ -1361,7 +1361,7 @@ Var And Scrolling Synced To Left Table</source>
     </message>
     <message>
         <source>Override Builtin New Game Data</source>
-        <translation>覆盖内置新游戏数据</translation>
+        <translation>覆盖内置新存档数据</translation>
     </message>
     <message>
         <source>Item Editor - Always Cap Quantity to 99</source>
@@ -1385,7 +1385,7 @@ Var And Scrolling Synced To Left Table</source>
     </message>
     <message>
         <source>World Map Viewer- Show int SpinBoxes for Leader ID and buggy ID</source>
-        <translation>世界地图查看器 - 显示Leader ID和buggy ID的整数微调框</translation>
+        <translation>世界地图查看器 - 显示队长ID和越野车ID的整数微调框</translation>
     </message>
     <message>
         <source>Editable Combo for Materia and Items</source>
@@ -1409,7 +1409,7 @@ Var And Scrolling Synced To Left Table</source>
     </message>
     <message>
         <source>Edit Places</source>
-        <translation>编辑地点</translation>
+        <translation>存档文件夹</translation>
     </message>
     <message>
         <source>PAL-DE</source>
@@ -1425,7 +1425,7 @@ Var And Scrolling Synced To Left Table</source>
     </message>
     <message>
         <source>Field Location - Show Map/X/Y/T/D</source>
-        <translation>野外位置 - 显示地图/X/Y/T/D</translation>
+        <translation>野外位置 - 显示地图/X/Y/T/D坐标值</translation>
     </message>
     <message>
         <source>Light Theme</source>
@@ -1445,7 +1445,7 @@ Var And Scrolling Synced To Left Table</source>
     </message>
     <message>
         <source>New Game Default Region </source>
-        <translation>新游戏默认区域</translation>
+        <translation>新存档默认区域</translation>
     </message>
     <message>
         <source>Raw Psx Files Only!</source>
@@ -1487,7 +1487,7 @@ Var And Scrolling Synced To Left Table</source>
     </message>
     <message>
         <source>Use Native File Dialogs</source>
-        <translation>使用原生文件对话框</translation>
+        <translation>使用系统默认位置</translation>
     </message>
     <message>
         <source>Options - Always Show Controller Mapping </source>
@@ -1515,7 +1515,7 @@ Var And Scrolling Synced To Left Table</source>
     </message>
     <message>
         <source>Path For Character Stat Files And Backups</source>
-        <translation>角色状态文件和备份的路径</translation>
+        <translation>角色状态文件和备份路径</translation>
     </message>
     <message>
         <source>Dark Theme</source>
@@ -1594,7 +1594,7 @@ Var And Scrolling Synced To Left Table</source>
     </message>
     <message>
         <source>Edit Places</source>
-        <translation>编辑地点</translation>
+        <translation>存档文件夹</translation>
     </message>
     <message>
         <source>Failed To Save File</source>
@@ -1736,7 +1736,7 @@ File:%1</source>
     </message>
     <message numerus="yes">
         <source>
- Game Uses %n Save Block(s)</source>
+ 游戏使用 %n 个存档块(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
         </translation>

--- a/translations/blackchocobo_zh_CN.ts
+++ b/translations/blackchocobo_zh_CN.ts
@@ -1,0 +1,1747 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_CN" sourcelanguage="en_US">
+<context>
+    <name>About</name>
+    <message>
+        <source>Version: %1</source>
+        <translation>版本：%1</translation>
+    </message>
+    <message>
+        <source>Polish Translation:</source>
+        <translation>波兰语翻译：</translation>
+    </message>
+    <message>
+        <source>Additonal Credits</source>
+        <translation>额外鸣谢</translation>
+    </message>
+    <message>
+        <source>Japanese Translation:</source>
+        <translation>日语翻译：</translation>
+    </message>
+    <message>
+        <source>Spanish Translation:</source>
+        <translation>西班牙语翻译：</translation>
+    </message>
+    <message>
+        <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Ubuntu&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a href=&quot;http://sourceforge.net/p/blackchocobo/donate&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#508ed8;&quot;&gt;Support this Project&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Ubuntu&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a href=&quot;http://sourceforge.net/p/blackchocobo/donate&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#508ed8;&quot;&gt;支持此项目&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <source>&amp;Close</source>
+        <translation>&amp;关闭</translation>
+    </message>
+    <message>
+        <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Ubuntu&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a href=&quot;https://github.com/sithlord48/blackchocobo/graphs/contributors&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#508ed8;&quot;&gt;Code Contributors&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Ubuntu&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a href=&quot;https://github.com/sithlord48/blackchocobo/graphs/contributors&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#508ed8;&quot;&gt;代码贡献者&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <source>Icons used In this Program</source>
+        <translation>此程序中使用的图标</translation>
+    </message>
+    <message>
+        <source>Qt: %1</source>
+        <translation>Qt：%1</translation>
+    </message>
+    <message>
+        <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Ubuntu&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a href=&quot;http://www.gnu.org/licenses/gpl.html&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#508ed8;&quot;&gt;License: GNU GPL Version 3&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Ubuntu&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a href=&quot;http://www.gnu.org/licenses/gpl.html&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#508ed8;&quot;&gt;许可证：GNU GPL 版本 3&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <source>About Black Chocobo</source>
+        <translation>关于黑色陆行鸟</translation>
+    </message>
+    <message>
+        <source>Translators</source>
+        <translation>翻译人员</translation>
+    </message>
+    <message>
+        <source>French Translation:</source>
+        <translation>法语翻译：</translation>
+    </message>
+    <message>
+        <source>German Translation:</source>
+        <translation>德语翻译：</translation>
+    </message>
+    <message>
+        <source>Black Chocobo </source>
+        <translation>黑色陆行鸟 </translation>
+    </message>
+    <message>
+        <source>ff7tk: %1</source>
+        <translation>ff7tk：%1</translation>
+    </message>
+    <message>
+        <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Ubuntu&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a href=&quot;https://github.com/sithlord48/blackchocobo&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#508ed8;&quot;&gt;Project Page&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Ubuntu&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a href=&quot;https://github.com/sithlord48/blackchocobo&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#508ed8;&quot;&gt;项目页面&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>BlackChocobo</name>
+    <message>
+        <source>#</source>
+        <translation>#</translation>
+    </message>
+    <message>
+        <source>.</source>
+        <translation>.</translation>
+    </message>
+    <message>
+        <source>/</source>
+        <translation>/</translation>
+    </message>
+    <message>
+        <source>:</source>
+        <translation>:</translation>
+    </message>
+    <message>
+        <source>AP</source>
+        <translation>AP</translation>
+    </message>
+    <message>
+        <source>F2</source>
+        <translation>F2</translation>
+    </message>
+    <message>
+        <source>F4</source>
+        <translation>F4</translation>
+    </message>
+    <message>
+        <source>F9</source>
+        <translation>F9</translation>
+    </message>
+    <message>
+        <source>Z:</source>
+        <translation>Z:</translation>
+    </message>
+    <message>
+        <source>id</source>
+        <translation>id</translation>
+    </message>
+    <message>
+        <source>1st</source>
+        <translation>第一名</translation>
+    </message>
+    <message>
+        <source>2nd</source>
+        <translation>第二名</translation>
+    </message>
+    <message>
+        <source>3rd</source>
+        <translation>第三名</translation>
+    </message>
+    <message>
+        <source>Bin</source>
+        <translation>Bin</translation>
+    </message>
+    <message>
+        <source>F10</source>
+        <translation>F10</translation>
+    </message>
+    <message>
+        <source>Dec</source>
+        <translation>Dec</translation>
+    </message>
+    <message>
+        <source>Hex</source>
+        <translation>Hex</translation>
+    </message>
+    <message>
+        <source>Min</source>
+        <translation>分</translation>
+    </message>
+    <message>
+        <source>Sec</source>
+        <translation>秒</translation>
+    </message>
+    <message>
+        <source>Sub</source>
+        <translation>潜水艇</translation>
+    </message>
+    <message>
+        <source>X: </source>
+        <translation>X: </translation>
+    </message>
+    <message>
+        <source>Y: </source>
+        <translation>Y: </translation>
+    </message>
+    <message>
+        <source>Hour</source>
+        <translation>时</translation>
+    </message>
+    <message>
+        <source>Misc</source>
+        <translation>杂项</translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation>无</translation>
+    </message>
+    <message>
+        <source>Slot</source>
+        <translation>存档位</translation>
+    </message>
+    <message>
+        <source>&amp;Edit</source>
+        <translation>&amp;编辑</translation>
+    </message>
+    <message>
+        <source>&amp;File</source>
+        <translation>&amp;文件</translation>
+    </message>
+    <message>
+        <source>&amp;Open</source>
+        <translation>&amp;打开</translation>
+    </message>
+    <message>
+        <source>&amp;Quit</source>
+        <translation>&amp;退出</translation>
+    </message>
+    <message>
+        <source>&amp;Save</source>
+        <translation>&amp;保存</translation>
+    </message>
+    <message>
+        <source>&amp;View</source>
+        <translation>&amp;查看</translation>
+    </message>
+    <message>
+        <source>Unknown Id in Buggy/Highwind Location</source>
+        <translation>Buggy/Highwind位置中的未知ID</translation>
+    </message>
+    <message>
+        <source>Spanish (PAL)</source>
+        <translation>西班牙语 (PAL)</translation>
+    </message>
+    <message>
+        <source>&amp;Spanish (PAL)</source>
+        <translation>&amp;西班牙语 (PAL)</translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Resets
+When you Pass thru Battle Square&apos;s Door Set Location To &amp;quot;Arena
+Lobby&amp;quot; so you can spend
+them&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;当你通过战斗广场的门时，位置会重置为“竞技场大厅”，这样你就可以使用它们了&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <source>Add Each Materia to Stock (end of list)</source>
+        <translation>将每个魔晶石添加到库存（列表末尾）</translation>
+    </message>
+    <message>
+        <source>Buggy</source>
+        <translation>越野车</translation>
+    </message>
+    <message>
+        <source>Crazy Course</source>
+        <translation>疯狂赛道</translation>
+    </message>
+    <message>
+        <source>He&amp;lp</source>
+        <translation>帮&amp;助</translation>
+    </message>
+    <message>
+        <source>Items</source>
+        <translation>道具</translation>
+    </message>
+    <message>
+        <source>Have Seen Pandora&apos;s Box</source>
+        <translation>已见过潘多拉之盒</translation>
+    </message>
+    <message>
+        <source>Party</source>
+        <translation>队伍</translation>
+    </message>
+    <message>
+        <source>Other</source>
+        <translation>其他</translation>
+    </message>
+    <message>
+        <source>&amp;Place Leader</source>
+        <translation>&amp;放置队长</translation>
+    </message>
+    <message>
+        <source>Show:</source>
+        <translation>显示：</translation>
+    </message>
+    <message>
+        <source>Time:</source>
+        <translation>时间：</translation>
+    </message>
+    <message>
+        <source>angle</source>
+        <translation>角度</translation>
+    </message>
+    <message>
+        <source>Unsaved Changes</source>
+        <translation>未保存的更改</translation>
+    </message>
+    <message>
+        <source>Replay Mission</source>
+        <translation>重玩剧情</translation>
+    </message>
+    <message>
+        <source> Played Video on Train?</source>
+        <translation> 在火车上播放过视频？</translation>
+    </message>
+    <message>
+        <source>Select Achievement File</source>
+        <translation>选择成就文件</translation>
+    </message>
+    <message>
+        <source>Avalanche Has Run To Hideout</source>
+        <translation>雪崩已逃到藏身处</translation>
+    </message>
+    <message numerus="yes">
+        <source>Game Uses %n Save Block(s)</source>
+        <translation>
+            <numerusform>游戏使用%n个存档块</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Coaster Shooter High Scores</source>
+        <translation>过山车射击游戏最高分</translation>
+    </message>
+    <message>
+        <source>New Game Plus Created - Using: %1</source>
+        <translation>新存档+已创建 - 使用：%1</translation>
+    </message>
+    <message>
+        <source>Black Chocobo</source>
+        <translation>黑色陆行鸟</translation>
+    </message>
+    <message>
+        <source>Black chocobo</source>
+        <translation>黑色陆行鸟</translation>
+    </message>
+    <message>
+        <source>Apply Selected Replay </source>
+        <translation>应用所选剧情</translation>
+    </message>
+    <message>
+        <source>Export Successful</source>
+        <translation>导出成功</translation>
+    </message>
+    <message>
+        <source>&amp;French (PAL)</source>
+        <translation>&amp;法语 (PAL)</translation>
+    </message>
+    <message>
+        <source>This Will Copy Cloud as is to young cloud (caitsith&apos;s slot). Sephiroth&apos;s stats will come directly from the Default Save. Be Sure to back up your CaitSith and Vincent if you want to use them again</source>
+        <translation>这会将当前克劳德的属性复制到年轻的克劳德，萨菲罗斯的属性将直接来自默认存档。这将会占用凯特西和文森特的角色栏位置，如果你想再次使用凯特西和文森特，请务必备份他们</translation>
+    </message>
+    <message>
+        <source>Import Canceled</source>
+        <translation>导入已取消</translation>
+    </message>
+    <message>
+        <source>Midgar Train Flags</source>
+        <translation>米德加列车标记</translation>
+    </message>
+    <message>
+        <source>Ultimate Weapons Hp</source>
+        <translation>究极神兵 HP</translation>
+    </message>
+    <message>
+        <source>Turtle Paradise</source>
+        <translation>龟道乐</translation>
+    </message>
+    <message>
+        <source>Buggy / Highwind</source>
+        <translation>越野车 / 飞空艇</translation>
+    </message>
+    <message>
+        <source>Create Cloud Save &amp;Folder</source>
+        <translation>创建云存档&amp;文件夹</translation>
+    </message>
+    <message>
+        <source>Bombing Mission</source>
+        <translation>爆破任务</translation>
+    </message>
+    <message>
+        <source>Current Slot:%1</source>
+        <translation>当前存档位：%1</translation>
+    </message>
+    <message>
+        <source>Selected Materia Skills and Stat Info</source>
+        <translation>所选魔晶石技能和属性信息</translation>
+    </message>
+    <message>
+        <source>KeyItem</source>
+        <translation>关键道具</translation>
+    </message>
+    <message>
+        <source>Jessie Has Been Unstuck</source>
+        <translation>杰西已不再卡住</translation>
+    </message>
+    <message>
+        <source>
+  Next Data Chunk @ Slot:%1</source>
+        <translation>
+  下一个数据块 @ 存档位：%1</translation>
+    </message>
+    <message>
+        <source>Party Leader</source>
+        <translation>队伍队长</translation>
+    </message>
+    <message>
+        <source>Error Loading File %1</source>
+        <translation>加载文件%1时出错</translation>
+    </message>
+    <message>
+        <source>Talked to Biggs</source>
+        <translation>已和比格斯交谈</translation>
+    </message>
+    <message>
+        <source>&amp;Achievement Editor</source>
+        <translation>&amp;成就编辑器</translation>
+    </message>
+    <message>
+        <source>Game Options</source>
+        <translation>游戏选项</translation>
+    </message>
+    <message>
+        <source>&amp;About</source>
+        <translation>&amp;关于</translation>
+    </message>
+    <message>
+        <source>Sector 7 - Slums Progress</source>
+        <translation>第七区 - 贫民窟进度</translation>
+    </message>
+    <message>
+        <source>Application Preferences</source>
+        <translation>应用程序偏好设置</translation>
+    </message>
+    <message>
+        <source>Save Changes to the File:
+%1</source>
+        <translation>保存更改到文件：
+%1</translation>
+    </message>
+    <message>
+        <source>-None-</source>
+        <translation>-无-</translation>
+    </message>
+    <message>
+        <source>2nd Door Opened</source>
+        <translation>第二扇门已打开</translation>
+    </message>
+    <message>
+        <source>When Box is Partially Checked (&quot;-&quot;) it will
+trigger showing that tutorial</source>
+        <translation>当复选框被部分选中（&quot;-&quot;）时，它将触发显示该教程</translation>
+    </message>
+    <message>
+        <source>Unknowns / Unused</source>
+        <translation>未知 / 未使用</translation>
+    </message>
+    <message>
+        <source>Destroy the Sector 5 Reactor </source>
+        <translation>摧毁五号魔晄炉</translation>
+    </message>
+    <message>
+        <source>E&amp;xport Current Character</source>
+        <translation>导&amp;出当前角色数据</translation>
+    </message>
+    <message>
+        <source>Bombing Mission Progress</source>
+        <translation>爆破任务进度</translation>
+    </message>
+    <message>
+        <source>&amp;Copy Current Slot</source>
+        <translation>&amp;复制当前存档位</translation>
+    </message>
+    <message>
+        <source>Alt+Left</source>
+        <translation>Alt+左</translation>
+    </message>
+    <message>
+        <source>Beat Ruby Weapon</source>
+        <translation>击败红宝石神兵</translation>
+    </message>
+    <message>
+        <source>Materia</source>
+        <translation>魔晶石</translation>
+    </message>
+    <message>
+        <source>Place &amp;Buggy/Highwind</source>
+        <translation>放置&amp;越野车/飞空艇</translation>
+    </message>
+    <message>
+        <source>Battle Arena</source>
+        <translation>斗技场</translation>
+    </message>
+    <message>
+        <source>Sa&amp;ve As</source>
+        <translation>另&amp;存为</translation>
+    </message>
+    <message>
+        <source>Buggy/Highwind</source>
+        <translation>越野车/飞空艇</translation>
+    </message>
+    <message>
+        <source>Remove ALL Materia </source>
+        <translation>移除所有魔晶石</translation>
+    </message>
+    <message>
+        <source>Have Won the Submarine Game</source>
+        <translation>已赢得潜水艇小游戏</translation>
+    </message>
+    <message>
+        <source>Party leader</source>
+        <translation>队伍队长</translation>
+    </message>
+    <message>
+        <source>Avalanche had meeting after Bombing Mission</source>
+        <translation>爆破任务后雪崩开会</translation>
+    </message>
+    <message>
+        <source>Ctrl+Shift+Ins</source>
+        <translation>Ctrl+Shift+Ins</translation>
+    </message>
+    <message>
+        <source>Ctrl+Shift+Del</source>
+        <translation>Ctrl+Shift+Del</translation>
+    </message>
+    <message>
+        <source>Load Failed</source>
+        <translation>加载失败</translation>
+    </message>
+    <message>
+        <source>Ctrl+E</source>
+        <translation>Ctrl+E</translation>
+    </message>
+    <message>
+        <source>Ctrl+O</source>
+        <translation>Ctrl+O</translation>
+    </message>
+    <message>
+        <source>Ctrl+Q</source>
+        <translation>Ctrl+Q</translation>
+    </message>
+    <message>
+        <source>Hex Editor</source>
+        <translation>十六进制编辑器</translation>
+    </message>
+    <message>
+        <source>&amp;Configure</source>
+        <translation>&amp;配置</translation>
+    </message>
+    <message>
+        <source>Funds </source>
+        <translation>资金</translation>
+    </message>
+    <message>
+        <source>Fort Condor</source>
+        <translation>秃鹫要塞</translation>
+    </message>
+    <message>
+        <source>German (PAL)</source>
+        <translation>德语 (PAL)</translation>
+    </message>
+    <message>
+        <source>Aeris Death</source>
+        <translation>爱丽丝之死</translation>
+    </message>
+    <message>
+        <source>Unlocked Yuffie </source>
+        <translation>已解锁尤菲</translation>
+    </message>
+    <message>
+        <source>Talked to Wedge Twice</source>
+        <translation>已和威吉交谈两次</translation>
+    </message>
+    <message>
+        <source>Place &amp;Wild Chocobo</source>
+        <translation>放置&amp;野陆行鸟</translation>
+    </message>
+    <message>
+        <source>Master</source>
+        <translation>最高等级</translation>
+    </message>
+    <message>
+        <source>Love Points</source>
+        <translation>好感度</translation>
+    </message>
+    <message>
+        <source>Time Played</source>
+        <translation>游玩时间</translation>
+    </message>
+    <message>
+        <source>Post Pan NMKIN_5</source>
+        <translation>平移后 NMKIN_5</translation>
+    </message>
+    <message>
+        <source>Can Fight Mystery Ninja in Forests</source>
+        <translation>可以在森林中与神秘忍者战斗</translation>
+    </message>
+    <message>
+        <source>Points</source>
+        <translation>点数</translation>
+    </message>
+    <message>
+        <source>Location</source>
+        <translation>位置</translation>
+    </message>
+    <message>
+        <source>Score:</source>
+        <translation>得分：</translation>
+    </message>
+    <message>
+        <source>Error Importing Slot %1</source>
+        <translation>导入存档槽 %1 时出错</translation>
+    </message>
+    <message>
+        <source>Event Progress</source>
+        <translation>事件进度</translation>
+    </message>
+    <message>
+        <source>&lt;------Left Table------
+Select Unknown Var To View
+Table Entries are Editable</source>
+        <translation>&lt;------左侧表格------
+选择未知变量查看
+表格条目可编辑</translation>
+    </message>
+    <message>
+        <source>Sector 7 Trainstation</source>
+        <translation>第七区火车站</translation>
+    </message>
+    <message>
+        <source>Game Region</source>
+        <translation>游戏区域</translation>
+    </message>
+    <message>
+        <source>Yellow chocobo</source>
+        <translation>黄色陆行鸟</translation>
+    </message>
+    <message>
+        <source>&amp;Japanese (NTSC-J)</source>
+        <translation>&amp;日语 (NTSC-J)</translation>
+    </message>
+    <message>
+        <source>Diamond / Ultimate / Ruby Weapon</source>
+        <translation>钻石/究极/红宝石神兵</translation>
+    </message>
+    <message>
+        <source>Uk &amp;English (PAL)</source>
+        <translation>英国&amp;英语 (PAL)</translation>
+    </message>
+    <message>
+        <source>Save FF7 Character File</source>
+        <translation>保存FF7角色文件</translation>
+    </message>
+    <message>
+        <source>Snowboard Mini Game </source>
+        <translation>滑雪小游戏</translation>
+    </message>
+    <message>
+        <source>Initial Settings</source>
+        <translation>初始设置</translation>
+    </message>
+    <message>
+        <source>Special Battle Wins</source>
+        <translation>特殊战斗胜利次数</translation>
+    </message>
+    <message>
+        <source>UK English (PAL)</source>
+        <translation>英国英语 (PAL)</translation>
+    </message>
+    <message>
+        <source>===Empty Slot===</source>
+        <translation>===空===</translation>
+    </message>
+    <message>
+        <source>Right click on map to easily set an item&apos;s
+location.</source>
+        <translation>右键点击地图可轻松放置。</translation>
+    </message>
+    <message>
+        <source>Exported Slot:%2 from %1 -&gt; %3</source>
+        <translation>已导出存档槽：%2 从 %1 -&gt; %3</translation>
+    </message>
+    <message>
+        <source>Tiny bronco</source>
+        <translation>飞机</translation>
+    </message>
+    <message>
+        <source>Cleared All Items</source>
+        <translation>已清除所有道具</translation>
+    </message>
+    <message>
+        <source>Battle Love Points</source>
+        <translation>战斗好感度</translation>
+    </message>
+    <message>
+        <source>Game Progress</source>
+        <translation>游戏进度</translation>
+    </message>
+    <message>
+        <source>Post Pan MD8_2</source>
+        <translation>平移后 MD8_2</translation>
+    </message>
+    <message>
+        <source>Place &amp;Diamond/Ultimate/Ruby Weapon</source>
+        <translation>放置&amp;钻石/究极/红宝石神兵</translation>
+    </message>
+    <message>
+        <source>Alt+Right</source>
+        <translation>Alt+右</translation>
+    </message>
+    <message>
+        <source>Japanese (NTSC-J)</source>
+        <translation>日语 (NTSC-J)</translation>
+    </message>
+    <message>
+        <source>Saving on the World Map</source>
+        <translation>世界地图存档</translation>
+    </message>
+    <message>
+        <source>TinyBronco/Chocobo</source>
+        <translation>飞机/陆行鸟</translation>
+    </message>
+    <message>
+        <source>&amp;Slot Region</source>
+        <translation>&amp;存档槽区域</translation>
+    </message>
+    <message>
+        <source>Save Error</source>
+        <translation>保存错误</translation>
+    </message>
+    <message>
+        <source>&amp;Import To Current Slot</source>
+        <translation>&amp;导入到当前存档槽</translation>
+    </message>
+    <message>
+        <source>Green chocobo</source>
+        <translation>绿色陆行鸟</translation>
+    </message>
+    <message>
+        <source>Talked to Jessie Before Looking At Map</source>
+        <translation>看地图前与杰西对话</translation>
+    </message>
+    <message>
+        <source>
+ End Of Linked Data</source>
+        <translation>
+ 链接数据结束</translation>
+    </message>
+    <message>
+        <source>------Right Table------&gt;
+Select A Slot To Compare
+Table is Read Only
+Var And Scrolling Synced To Left Table</source>
+        <translation>------右侧表格------&gt;
+选择一个存档槽进行比较
+表格只读
+变量和滚动与左侧表格同步</translation>
+    </message>
+    <message>
+        <source>Talked To Trainman 3 times</source>
+        <translation>与列车员对话3次</translation>
+    </message>
+    <message>
+        <source>Select A File to Save As</source>
+        <translation>选择要保存的文件</translation>
+    </message>
+    <message>
+        <source>Map Id: </source>
+        <translation>地图ID: </translation>
+    </message>
+    <message>
+        <source>Export Failed</source>
+        <translation>导出失败</translation>
+    </message>
+    <message>
+        <source>New Game Created - Using: %1</source>
+        <translation>新存档已创建 - 使用：%1</translation>
+    </message>
+    <message>
+        <source>Clear All Stolen Materia</source>
+        <translation>清除所有被盗魔晶石</translation>
+    </message>
+    <message>
+        <source>Place &amp;Tiny Bronco/Chocobo</source>
+        <translation>放置&amp;飞机/陆行鸟</translation>
+    </message>
+    <message>
+        <source>All Materia Added!</source>
+        <translation>所有魔晶石已添加！</translation>
+    </message>
+    <message>
+        <source>Controling the Sub</source>
+        <translation>控制潜水艇</translation>
+    </message>
+    <message>
+        <source>Expert Course</source>
+        <translation>专家级赛道</translation>
+    </message>
+    <message>
+        <source>The Plate is Falling</source>
+        <translation>圆盘正在坠落</translation>
+    </message>
+    <message>
+        <source>ChurchProgress</source>
+        <translation>教堂进度</translation>
+    </message>
+    <message>
+        <source>Main Progression</source>
+        <translation>主线进度</translation>
+    </message>
+    <message>
+        <source>Imported %1 -&gt; Slot:%2</source>
+        <translation>已导入 %1 -&gt; 存档槽：%2</translation>
+    </message>
+    <message>
+        <source>Select FF7 Character Stat File</source>
+        <translation>选择FF7角色数据文件</translation>
+    </message>
+    <message>
+        <source>Record </source>
+        <translation>记录 </translation>
+    </message>
+    <message>
+        <source>Post Pillar Pan Video</source>
+        <translation>柱子平移视频后</translation>
+    </message>
+    <message>
+        <source>&amp;Select Slot</source>
+        <translation>&amp;选择存档槽</translation>
+    </message>
+    <message>
+        <source>Tiny Bronco / Chocobo</source>
+        <translation>飞机 / 陆行鸟</translation>
+    </message>
+    <message>
+        <source>Played piano during flashback</source>
+        <translation>回忆中弹奏了钢琴</translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Number of wins for the &amp;quot;Special Battle&amp;quot;. Mini-Game Reward is based on number of wins.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;“特殊战斗”的胜利次数。小游戏奖励基于胜利次数。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <source>The Bomb Was Set</source>
+        <translation>炸弹已放置</translation>
+    </message>
+    <message>
+        <source>DonProgress</source>
+        <translation>唐进度</translation>
+    </message>
+    <message>
+        <source>The Date Scene</source>
+        <translation>约会场景</translation>
+    </message>
+    <message>
+        <source>International (NTSC-J)</source>
+        <translation>国际版 (NTSC-J)</translation>
+    </message>
+    <message>
+        <source>Unlocked Vincent</source>
+        <translation>已解锁文森特</translation>
+    </message>
+    <message>
+        <source>Party&apos;s Materia Stock</source>
+        <translation>队伍的魔晶石</translation>
+    </message>
+    <message>
+        <source>&amp;International (NTSC-J)</source>
+        <translation>&amp;国际版 (NTSC-J)</translation>
+    </message>
+    <message>
+        <source>Place &amp;Sub</source>
+        <translation>放置&amp;潜水艇</translation>
+    </message>
+    <message>
+        <source>Unknown Var:</source>
+        <translation>未知变量：</translation>
+    </message>
+    <message>
+        <source>Unknown Vars</source>
+        <translation>未知变量</translation>
+    </message>
+    <message>
+        <source>Elevator Door Open</source>
+        <translation>电梯门已开</translation>
+    </message>
+    <message>
+        <source>Failed to save file
+%1</source>
+        <translation>保存文件失败
+%1</translation>
+    </message>
+    <message>
+        <source>Replay the bombing mission from right after you get off the train.</source>
+        <translation>下火车后的爆破任务。</translation>
+    </message>
+    <message>
+        <source>Chocobo</source>
+        <translation>陆行鸟</translation>
+    </message>
+    <message>
+        <source>%1:
+%2 is Not a FF7 Character Stat File.</source>
+        <translation>%1:
+%2 不是一个FF7角色数据文件。</translation>
+    </message>
+    <message>
+        <source>PSX Save Data</source>
+        <translation>PSX存档数据</translation>
+    </message>
+    <message>
+        <source>The Church In The Slums</source>
+        <translation>贫民窟的教堂</translation>
+    </message>
+    <message>
+        <source>
+ Mid-Linked Block </source>
+        <translation>
+ 中间链接块</translation>
+    </message>
+    <message>
+        <source>Field Location</source>
+        <translation>场景位置</translation>
+    </message>
+    <message>
+        <source>&#xa0; &#xa0; &#xa0; &#xa0; &#xa0;INFO ON CURRENTLY SELECTED REPLAY MISSION</source>
+        <translation type="vanished">&#xa0; &#xa0; &#xa0; &#xa0; &#xa0;选择要重玩的剧情</translation>
+    </message>
+    <message>
+        <source>&amp;Paste Slot</source>
+        <translation>&amp;粘贴存档槽</translation>
+    </message>
+    <message>
+        <source>Test Data</source>
+        <translation>测试数据</translation>
+    </message>
+    <message>
+        <source>Progression Reset Complete</source>
+        <translation>进度重置完成</translation>
+    </message>
+    <message>
+        <source>New &amp;Game+ </source>
+        <translation>新&amp;游戏+ </translation>
+    </message>
+    <message>
+        <source>Pair At Station agree</source>
+        <translation>车站情侣同意</translation>
+    </message>
+    <message>
+        <source>Beginner Course</source>
+        <translation>初级赛道</translation>
+    </message>
+    <message>
+        <source>US English (NTSC-U)</source>
+        <translation>美国英语 (NTSC-U)</translation>
+    </message>
+    <message>
+        <source>Diamond / Ultimate / Ruby&#xa0; Weapon</source>
+        <translation type="vanished">钻石/究极/红宝石 神兵</translation>
+    </message>
+    <message>
+        <source>PsxName:</source>
+        <translation>Psx名称：</translation>
+    </message>
+    <message>
+        <source>&amp;German (PAL)</source>
+        <translation>&amp;德语 (PAL)</translation>
+    </message>
+    <message>
+        <source>Meeting Aeris</source>
+        <translation>遇见爱丽丝</translation>
+    </message>
+    <message>
+        <source>Disc&#xa0; #</source>
+        <translation type="vanished">光盘  #</translation>
+    </message>
+    <message>
+        <source>All Items Added</source>
+        <translation>所有道具已添加</translation>
+    </message>
+    <message>
+        <source>Playstation Save Info</source>
+        <translation>Playstation存档信息</translation>
+    </message>
+    <message>
+        <source>G-Bike High Score</source>
+        <translation>G型摩托最高分</translation>
+    </message>
+    <message>
+        <source>&amp;Reload</source>
+        <translation>&amp;重新加载</translation>
+    </message>
+    <message>
+        <source>Ctrl+Ins</source>
+        <translation>Ctrl+Ins</translation>
+    </message>
+    <message>
+        <source>No Description Text</source>
+        <translation>无描述文本</translation>
+    </message>
+    <message>
+        <source>Number of Steps</source>
+        <translation>步数</translation>
+    </message>
+    <message>
+        <source>&amp;Previous Slot</source>
+        <translation>&amp;上一个存档槽</translation>
+    </message>
+    <message>
+        <source>Barret called us</source>
+        <translation>巴雷特呼叫我们</translation>
+    </message>
+    <message>
+        <source>Countdown Timer</source>
+        <translation>倒计时器</translation>
+    </message>
+    <message>
+        <source>Wild Chocobo</source>
+        <translation>野生陆行鸟</translation>
+    </message>
+    <message>
+        <source>Wild chocobo</source>
+        <translation>野生陆行鸟</translation>
+    </message>
+    <message>
+        <source>(Deleted)</source>
+        <translation>(已删除)</translation>
+    </message>
+    <message>
+        <source>Failed to Load File</source>
+        <translation>加载文件失败</translation>
+    </message>
+    <message>
+        <source>Character Export Successful</source>
+        <translation>角色导出成功</translation>
+    </message>
+    <message>
+        <source>Replay the Date Scene, Your Location will be set To The Ropeway Station Talk to man by the Tram to start event. If Your Looking for a special Date be sure to set your love points too.</source>
+        <translation>你的位置将被设置为观光缆车站。与电车旁的人对话开始事件。如果你正在寻找一个特别的约会，请务必设置你的好感度。</translation>
+    </message>
+    <message>
+        <source>Imported Slot:%2 from %1 -&gt; Slot:%3</source>
+        <translation>已导入存档槽：%2 从 %1 -&gt; 存档槽：%3</translation>
+    </message>
+    <message>
+        <source>Save Slot</source>
+        <translation>存档槽</translation>
+    </message>
+    <message>
+        <source>Cannot read file %1:
+    %2.</source>
+        <translation type="vanished">无法读取文件 %1:
+    %2。</translation>
+    </message>
+    <message>
+        <source>&amp;New Game</source>
+        <translation>&amp;新存档</translation>
+    </message>
+    <message>
+        <source>Builtin Data</source>
+        <translation>内置数据</translation>
+    </message>
+    <message>
+        <source>Set Replay Mission below to set the game back to that mission. This will automatically set your save location and disc # as well as Quest Progression vars. DO NOT OVERWRITE YOUR CURRENT SAVE when using this feature; I cannot promise that you will be able to play from any replay until the end of the game, or that any given replay will work in your save. This feature is still under development.</source>
+        <translation>在下方设置重玩剧情，将游戏恢复到该剧情。这将自动设置你的存档位置、光盘号以及剧情进度变量。使用此功能时，请勿覆盖你当前的存档；我无法保证你所选的剧情一直玩到游戏结束，或许所有的重玩剧情都能在你的存档中正常工作。此功能仍在开发中。</translation>
+    </message>
+    <message>
+        <source>&amp;Settings</source>
+        <translation>&amp;设置</translation>
+    </message>
+    <message>
+        <source>&amp;Us English (NTSC-U)</source>
+        <translation>&amp;美国英语 (NTSC-U)</translation>
+    </message>
+    <message>
+        <source>Talked To soldier two times</source>
+        <translation>与士兵对话两次</translation>
+    </message>
+    <message>
+        <source>Clea&amp;r Slot</source>
+        <translation>清&amp;除存档槽</translation>
+    </message>
+    <message>
+        <source>Gold chocobo</source>
+        <translation>金色陆行鸟</translation>
+    </message>
+    <message>
+        <source>Ctrl+Shift+=</source>
+        <translation>Ctrl+Shift+=</translation>
+    </message>
+    <message>
+        <source>Ctrl+Shift+C</source>
+        <translation>Ctrl+Shift+C</translation>
+    </message>
+    <message>
+        <source>Ctrl+Shift+N</source>
+        <translation>Ctrl+Shift+N</translation>
+    </message>
+    <message>
+        <source>Ctrl+Shift+S</source>
+        <translation>Ctrl+Shift+S</translation>
+    </message>
+    <message>
+        <source>Ctrl+Shift+V</source>
+        <translation>Ctrl+Shift+V</translation>
+    </message>
+    <message>
+        <source>Blue chocobo</source>
+        <translation>蓝色陆行鸟</translation>
+    </message>
+    <message>
+        <source>Replay the death of Aeris.This option Will remove Aeris from your PHS</source>
+        <translation>此选项将从你的PHS中移除爱丽丝</translation>
+    </message>
+    <message>
+        <source>Can Show Pillar Pan Video</source>
+        <translation>可以显示柱子平移视频</translation>
+    </message>
+    <message>
+        <source>Open Final Fantasy 7 Save</source>
+        <translation>打开最终幻想7存档</translation>
+    </message>
+    <message>
+        <source>Set Save Location: %1</source>
+        <translation>设置保存位置：%1</translation>
+    </message>
+    <message>
+        <source>Battle Points</source>
+        <translation>战斗点数</translation>
+    </message>
+    <message>
+        <source>Dat File (*.dat)</source>
+        <translation>Dat文件 (*.dat)</translation>
+    </message>
+    <message>
+        <source>Cloud&apos;s Flashback</source>
+        <translation>克劳德的回忆</translation>
+    </message>
+    <message>
+        <source>Set To Reactor 5 Mode</source>
+        <translation>设置为五号魔晄炉模式</translation>
+    </message>
+    <message>
+        <source>Bombing Mission Start Flag</source>
+        <translation>爆破任务开始标记</translation>
+    </message>
+    <message>
+        <source>Beat Emerald Weapon</source>
+        <translation>击败绿宝石神兵</translation>
+    </message>
+    <message>
+        <source>Materia Stolen By Yuffie</source>
+        <translation>尤菲偷走的魔晶石</translation>
+    </message>
+    <message>
+        <source>Global Progress</source>
+        <translation>全局进度</translation>
+    </message>
+    <message>
+        <source>1st Door Open</source>
+        <translation>第一扇门已开</translation>
+    </message>
+    <message>
+        <source>French (PAL)</source>
+        <translation>法语 (PAL)</translation>
+    </message>
+    <message>
+        <source>Visible On World Map</source>
+        <translation>在世界地图上可见</translation>
+    </message>
+    <message>
+        <source>Worldmap Location</source>
+        <translation>世界地图位置</translation>
+    </message>
+    <message>
+        <source>Cait Sith and Vincent should not be enabled if they are disabled in the Party tab.</source>
+        <translation>如果凯特西和文森特在队伍标签页中被禁用，则不应在此处启用。</translation>
+    </message>
+    <message>
+        <source>Save Point Location In North Crater</source>
+        <translation>大空洞存档点位置</translation>
+    </message>
+    <message>
+        <source>Trigger Game Over (countdown reached 0)</source>
+        <translation>触发游戏结束（倒计时归零）</translation>
+    </message>
+    <message>
+        <source>Post Electrical Effect MD8_3</source>
+        <translation>电效应后 MD8_3</translation>
+    </message>
+    <message>
+        <source>I&amp;mport Current Character</source>
+        <translation>导&amp;入当前角色数据</translation>
+    </message>
+    <message>
+        <source>sliders show </source>
+        <translation>滑块显示 </translation>
+    </message>
+    <message>
+        <source>Escape From Reactor </source>
+        <translation>逃离反应炉 </translation>
+    </message>
+    <message>
+        <source>&amp;Next Slot</source>
+        <translation>&amp;下一个存档槽</translation>
+    </message>
+    <message>
+        <source>Compare To Slot</source>
+        <translation>与存档槽比较</translation>
+    </message>
+    <message>
+        <source>FF7 Character Stat File(*.char)</source>
+        <translation>FF7角色数据文件(*.char)</translation>
+    </message>
+    <message>
+        <source>Character Export Failed</source>
+        <translation>角色导出失败</translation>
+    </message>
+    <message>
+        <source>Sector 7 Pillar</source>
+        <translation>第七区支柱</translation>
+    </message>
+    <message>
+        <source>Highwind</source>
+        <translation>飞空艇</translation>
+    </message>
+    <message>
+        <source>Tutorials Seen</source>
+        <translation>已看过的教程</translation>
+    </message>
+    <message>
+        <source>Elevator On 2nd Floor</source>
+        <translation>电梯在二楼</translation>
+    </message>
+    <message>
+        <source>Diamond / Ultimate / Ruby  Weapon</source>
+        <translation>钻石/究极/红宝石 神兵</translation>
+    </message>
+    <message>
+        <source>Disc  #</source>
+        <translation>光盘  #</translation>
+    </message>
+    <message>
+        <source>Cannot read file %1:
+%2.</source>
+        <translation>无法读取文件 %1:
+%2.</translation>
+    </message>
+    <message>
+        <source>         INFO ON CURRENTLY SELECTED REPLAY MISSION</source>
+        <translation>选择要重玩的剧情</translation>
+    </message>
+</context>
+<context>
+    <name>ItemTab</name>
+    <message>
+        <source>GP</source>
+        <translation>GP</translation>
+    </message>
+    <message>
+        <source>Gil</source>
+        <translation>金钱</translation>
+    </message>
+    <message>
+        <source>Money</source>
+        <translation>金钱</translation>
+    </message>
+    <message>
+        <source>Unused KeyItems</source>
+        <translation>未使用的关键道具</translation>
+    </message>
+    <message>
+        <source>Add Max of All Items</source>
+        <translation>添加所有道具最大数量</translation>
+    </message>
+    <message>
+        <source>Clear All Items</source>
+        <translation>清除所有道具</translation>
+    </message>
+    <message>
+        <source>Battles</source>
+        <translation>战斗次数</translation>
+    </message>
+    <message>
+        <source>Search For &quot;KeyItem&quot; using item search mode on the location tab</source>
+        <translation>跳转到“位置“标签页搜索“关键道具”</translation>
+    </message>
+    <message>
+        <source>Escapes</source>
+        <translation>逃跑次数</translation>
+    </message>
+    <message>
+        <source>Inventory</source>
+        <translation>道具栏</translation>
+    </message>
+    <message>
+        <source>KeyItems</source>
+        <translation>关键道具</translation>
+    </message>
+    <message>
+        <source>Mystery panties</source>
+        <translation>神秘的内裤</translation>
+    </message>
+    <message>
+        <source>Letter to a Wife</source>
+        <translation>给妻子的信</translation>
+    </message>
+    <message>
+        <source>Turtle Paradise Flyers Collected</source>
+        <translation>龟道乐宣传单收集</translation>
+    </message>
+    <message>
+        <source>Letter to a Daughter</source>
+        <translation>给女儿的信</translation>
+    </message>
+    <message>
+        <source>Search for &quot;Turtle Paradise&quot; using item search mode on the location tab</source>
+        <translation>跳转到“位置“标签页搜索“龟道乐”</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <source>TRANSLATE TO YOUR LANGUAGE NAME</source>
+        <translation>简体中文</translation>
+    </message>
+</context>
+<context>
+    <name>Options</name>
+    <message>
+        <source>Save</source>
+        <translation>存档</translation>
+    </message>
+    <message>
+        <source>CharEditor - Simulate Leveling Up / Down</source>
+        <translation>角色编辑器 - 模拟升级/降级</translation>
+    </message>
+    <message>
+        <source>PAL-E</source>
+        <translation>PAL-E</translation>
+    </message>
+    <message>
+        <source>Paths</source>
+        <translation>路径</translation>
+    </message>
+    <message>
+        <source>Select A Default Save Game (Must Be Raw PSX)</source>
+        <translation>选择一个默认存档（必须是原始PSX格式）</translation>
+    </message>
+    <message>
+        <source>Override Builtin New Game Data</source>
+        <translation>覆盖内置新存档数据</translation>
+    </message>
+    <message>
+        <source>Item Editor - Always Cap Quantity to 99</source>
+        <translation>道具编辑器 - 始终将数量上限设为99</translation>
+    </message>
+    <message>
+        <source>Default Path For Loading All Saves</source>
+        <translation>加载所有存档的默认文件夹路径</translation>
+    </message>
+    <message>
+        <source>NTSC-JI</source>
+        <translation>NTSC-JI</translation>
+    </message>
+    <message>
+        <source>Chocobo Manager - Show Pcount / Personality</source>
+        <translation>陆行鸟管理器 - 显示P计数/个性</translation>
+    </message>
+    <message>
+        <source>Path For PC (.ff7) Saves</source>
+        <translation>PC (.ff7) 存档文件夹路径</translation>
+    </message>
+    <message>
+        <source>World Map Viewer- Show int SpinBoxes for Leader ID and buggy ID</source>
+        <translation>世界地图查看器 - 显示队长ID和越野车ID的整数微调框</translation>
+    </message>
+    <message>
+        <source>Editable Combo for Materia and Items</source>
+        <translation>魔晶石和道具的可编辑组合框</translation>
+    </message>
+    <message>
+        <source>Create A Backup when Overwriting a file</source>
+        <translation>覆盖文件时创建备份</translation>
+    </message>
+    <message>
+        <source>Game Progress - Show Untested</source>
+        <translation>游戏进度 - 显示未测试选项</translation>
+    </message>
+    <message>
+        <source>NTSC-J</source>
+        <translation>NTSC-J</translation>
+    </message>
+    <message>
+        <source>NTSC-U</source>
+        <translation>NTSC-U</translation>
+    </message>
+    <message>
+        <source>Edit Places</source>
+        <translation>存档文件夹</translation>
+    </message>
+    <message>
+        <source>PAL-DE</source>
+        <translation>PAL-DE</translation>
+    </message>
+    <message>
+        <source>PAL-ES</source>
+        <translation>PAL-ES</translation>
+    </message>
+    <message>
+        <source>PAL-FR</source>
+        <translation>PAL-FR</translation>
+    </message>
+    <message>
+        <source>Field Location - Show Map/X/Y/T/D</source>
+        <translation>场景位置 - 显示地图/X/Y/T/D坐标值</translation>
+    </message>
+    <message>
+        <source>Light Theme</source>
+        <translation>浅色主题</translation>
+    </message>
+    <message>
+        <source>Select A Directory To Save mcd/mcr saves</source>
+        <translation>选择保存mcd/mcr存档的目录</translation>
+    </message>
+    <message>
+        <source>Options</source>
+        <translation>选项</translation>
+    </message>
+    <message>
+        <source>Close and save changes</source>
+        <translation>关闭并保存更改</translation>
+    </message>
+    <message>
+        <source>New Game Default Region </source>
+        <translation>新存档默认区域</translation>
+    </message>
+    <message>
+        <source>Raw Psx Files Only!</source>
+        <translation>仅限原始PSX文件！</translation>
+    </message>
+    <message>
+        <source>Show Experimental TestData Tab</source>
+        <translation>显示实验性测试数据标签页</translation>
+    </message>
+    <message>
+        <source>Fusion is the recommended theme&#xa0;
+&#xa0;Other themes may contain graphical issues.</source>
+        <translation type="vanished">Fusion是推荐主题
+其他主题可能存在图形问题。</translation>
+    </message>
+    <message>
+        <source>Edit the Places show in sidebar on file dialogs</source>
+        <translation>编辑文件对话框侧边栏中显示的地点</translation>
+    </message>
+    <message>
+        <source>CharEditor - Advanced Mode</source>
+        <translation>角色编辑器 - 高级模式</translation>
+    </message>
+    <message>
+        <source>Reset values to stored settings</source>
+        <translation>将值重置为已存储的设置</translation>
+    </message>
+    <message>
+        <source>Path For Emulator Memory Cards  </source>
+        <translation>模拟器记忆卡的文件夹路径</translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The Native Dialog is unable to provide filename suggestions&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;原生对话框无法提供文件名建议&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <source>System Theme</source>
+        <translation>系统主题</translation>
+    </message>
+    <message>
+        <source>Use Native File Dialogs</source>
+        <translation>使用系统默认位置</translation>
+    </message>
+    <message>
+        <source>Options - Always Show Controller Mapping </source>
+        <translation>选项 - 始终显示控制器映射 </translation>
+    </message>
+    <message>
+        <source>Editing</source>
+        <translation>编辑</translation>
+    </message>
+    <message>
+        <source>Application Language</source>
+        <translation>应用程序语言</translation>
+    </message>
+    <message>
+        <source>Select A Location To Save Character Stat Files</source>
+        <translation>选择保存角色数据文件的位置</translation>
+    </message>
+    <message>
+        <source>Application Color Scheme</source>
+        <translation>应用程序配色方案</translation>
+    </message>
+    <message>
+        <source>Reset values to defaults</source>
+        <translation>将值重置为默认值</translation>
+    </message>
+    <message>
+        <source>Path For Character Stat Files And Backups</source>
+        <translation>角色数据和备份文件夹路径</translation>
+    </message>
+    <message>
+        <source>Dark Theme</source>
+        <translation>深色主题</translation>
+    </message>
+    <message>
+        <source>Close and forget changes</source>
+        <translation>关闭并放弃更改</translation>
+    </message>
+    <message>
+        <source>General</source>
+        <translation>通用</translation>
+    </message>
+    <message>
+        <source>Select A Directory To Save FF7 PC Saves</source>
+        <translation>选择保存FF7 PC存档的目录</translation>
+    </message>
+    <message>
+        <source>Select A Directory To Load FF7 PC Saves From</source>
+        <translation>选择加载FF7 PC存档的目录</translation>
+    </message>
+    <message>
+        <source>Application Style</source>
+        <translation>应用程序样式</translation>
+    </message>
+    <message>
+        <source>Show Placeholders In Materia and Item Selection</source>
+        <translation>在魔晶石和道具选择中显示占位符</translation>
+    </message>
+    <message>
+        <source>Fusion is the recommended theme 
+ Other themes may contain graphical issues.</source>
+        <translation>推荐使用 Fusion 主题。
+其他主题可能存在图形问题。</translation>
+    </message>
+</context>
+<context>
+    <name>PartyTab</name>
+    <message>
+        <source>Black Chocobo</source>
+        <translation>黑色陆行鸟</translation>
+    </message>
+    <message>
+        <source>-Empty-</source>
+        <translation>-空-</translation>
+    </message>
+    <message>
+        <source>Click on a Char To Edit  ===&gt;</source>
+        <translation>点击角色进行编辑&#xa0; ===&gt;</translation>
+    </message>
+    <message>
+        <source>Do You Want To Also Replace %1&apos;s Equipment and Materia?</source>
+        <translation>您是否也要替换 %1 的装备和魔晶石？</translation>
+    </message>
+    <message>
+        <source>Party Members</source>
+        <translation>队伍成员</translation>
+    </message>
+    <message>
+        <source>Selected Character Max Stats/Weapons/Materia</source>
+        <translation>选择的角色 [属性/装备/魔晶石] 最大化</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <source>Close</source>
+        <translation>关闭</translation>
+    </message>
+    <message>
+        <source>Add a place</source>
+        <translation>添加地点</translation>
+    </message>
+    <message>
+        <source>Adjust the play time?</source>
+        <translation>调整游戏时间吗？</translation>
+    </message>
+    <message>
+        <source>Edit Places</source>
+        <translation>存档文件夹</translation>
+    </message>
+    <message>
+        <source>Failed To Save File</source>
+        <translation>保存文件失败</translation>
+    </message>
+    <message>
+        <source>Places</source>
+        <translation>地点</translation>
+    </message>
+    <message>
+        <source>Remove selected place</source>
+        <translation>移除选定地点</translation>
+    </message>
+    <message>
+        <source>Close and save changes</source>
+        <translation>关闭并保存更改</translation>
+    </message>
+    <message>
+        <source>Restore default places</source>
+        <translation>恢复默认地点</translation>
+    </message>
+    <message>
+        <source>PAL -&gt; NTSC Conversion</source>
+        <translation>PAL -&gt; NTSC 转换</translation>
+    </message>
+    <message>
+        <source>Reset values to stored settings</source>
+        <translation>重置为已存储设置</translation>
+    </message>
+    <message>
+        <source>Select a path to add to places</source>
+        <translation>选择要添加到地点的路径</translation>
+    </message>
+    <message>
+        <source>NTSC -&gt; PAL Conversion</source>
+        <translation>NTSC -&gt; PAL 转换</translation>
+    </message>
+    <message>
+        <source>Achievement Editor</source>
+        <translation>成就编辑器</translation>
+    </message>
+    <message>
+        <source>Save Changes</source>
+        <translation>保存更改</translation>
+    </message>
+    <message>
+        <source>Close and forget changes</source>
+        <translation>关闭并放弃更改</translation>
+    </message>
+    <message>
+        <source>Old region was %1hz
+New region is %2hz</source>
+        <translation>旧区域为 %1 赫兹
+新区域为 %2 赫兹</translation>
+    </message>
+    <message>
+        <source>Failed To Write File
+File:%1</source>
+        <translation>写入文件失败
+文件：%1</translation>
+    </message>
+</context>
+<context>
+    <name>UndoStack</name>
+    <message>
+        <source>Delete %1 chars</source>
+        <translation>删除 %1 个字符</translation>
+    </message>
+    <message>
+        <source>Inserting %1 bytes</source>
+        <translation>插入 %1 字节</translation>
+    </message>
+    <message>
+        <source>Overwrite %1 chars</source>
+        <translation>覆盖 %1 个字符</translation>
+    </message>
+</context>
+<context>
+    <name>errbox</name>
+    <message>
+        <source>ERROR</source>
+        <translation>错误</translation>
+    </message>
+    <message>
+        <source>&#xa0; &#xa0; &#xa0; End Of Linked Blocks</source>
+        <translation type="vanished">&#xa0; &#xa0; &#xa0; 链接块末尾</translation>
+    </message>
+    <message numerus="yes">
+        <source>
+&#xa0;Game Uses %n Save Block(s)</source>
+        <translation type="vanished">
+            <numerusform>
+&#xa0;游戏使用 %n 个存档块</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>
+   Next Data Chunk @ Slot:%1</source>
+        <translation>
+&#xa0; &#xa0;下一数据块 @ 插槽：%1</translation>
+    </message>
+    <message>
+        <source>       Mid-Linked Block</source>
+        <translation>&#xa0; &#xa0; &#xa0; &#xa0;中间链接块</translation>
+    </message>
+    <message>
+        <source>    Mid-Linked Block (Deleted)</source>
+        <translation>&#xa0; &#xa0; 中间链接块（已删除）</translation>
+    </message>
+    <message>
+        <source>Slot:%1
+</source>
+        <translation>插槽：%1
+</translation>
+    </message>
+    <message>
+        <source>View Anyway</source>
+        <translation>无论如何都查看</translation>
+    </message>
+    <message>
+        <source>Non Final Fantasy VII Slot</source>
+        <translation>非最终幻想VII插槽</translation>
+    </message>
+    <message>
+        <source>&#xa0; &#xa0; &#xa0; End Of Linked Blocks (Deleted)</source>
+        <translation type="vanished">&#xa0; &#xa0; &#xa0; 链接块末尾（已删除）</translation>
+    </message>
+    <message>
+        <source>E&amp;xport Slot</source>
+        <translation>导&amp;出插槽</translation>
+    </message>
+    <message>
+        <source>      End Of Linked Blocks</source>
+        <translation>      链接块末尾（已删除）</translation>
+    </message>
+    <message>
+        <source>      End Of Linked Blocks (Deleted)</source>
+        <translation>      链接块末尾（已删除）</translation>
+    </message>
+    <message numerus="yes">
+        <source>
+ Game Uses %n Save Block(s)</source>
+        <translation>
+            <numerusform>游戏使用%n个存档块</numerusform>
+        </translation>
+    </message>
+</context>
+</TS>

--- a/translations/blackchocobo_zh_TW.ts
+++ b/translations/blackchocobo_zh_TW.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="zh" sourcelanguage="en_US">
+<TS version="2.1" language="zh_TW" sourcelanguage="en_US">
 <context>
     <name>About</name>
     <message>
@@ -9,19 +9,19 @@
     </message>
     <message>
         <source>Polish Translation:</source>
-        <translation>波兰语翻译：</translation>
+        <translation>波蘭語翻譯：</translation>
     </message>
     <message>
         <source>Additonal Credits</source>
-        <translation>额外鸣谢</translation>
+        <translation>額外鳴謝</translation>
     </message>
     <message>
         <source>Japanese Translation:</source>
-        <translation>日语翻译：</translation>
+        <translation>日語翻譯：</translation>
     </message>
     <message>
         <source>Spanish Translation:</source>
-        <translation>西班牙语翻译：</translation>
+        <translation>西班牙語翻譯：</translation>
     </message>
     <message>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
@@ -33,11 +33,11 @@ p, li { white-space: pre-wrap; }
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Ubuntu&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a href=&quot;http://sourceforge.net/p/blackchocobo/donate&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#508ed8;&quot;&gt;支持此项目&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a href=&quot;http://sourceforge.net/p/blackchocobo/donate&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#508ed8;&quot;&gt;支持此項目&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>&amp;Close</source>
-        <translation>&amp;关闭</translation>
+        <translation>&amp;關閉</translation>
     </message>
     <message>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
@@ -49,11 +49,11 @@ p, li { white-space: pre-wrap; }
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Ubuntu&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a href=&quot;https://github.com/sithlord48/blackchocobo/graphs/contributors&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#508ed8;&quot;&gt;代码贡献者&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a href=&quot;https://github.com/sithlord48/blackchocobo/graphs/contributors&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#508ed8;&quot;&gt;代碼貢獻者&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>Icons used In this Program</source>
-        <translation>此程序中使用的图标</translation>
+        <translation>此程序中使用的圖標</translation>
     </message>
     <message>
         <source>Qt: %1</source>
@@ -69,27 +69,27 @@ p, li { white-space: pre-wrap; }
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Ubuntu&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a href=&quot;http://www.gnu.org/licenses/gpl.html&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#508ed8;&quot;&gt;许可证：GNU GPL 版本 3&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a href=&quot;http://www.gnu.org/licenses/gpl.html&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#508ed8;&quot;&gt;許可證：GNU GPL 版本 3&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>About Black Chocobo</source>
-        <translation>关于黑色陆行鸟</translation>
+        <translation>關於黑色陸行鳥</translation>
     </message>
     <message>
         <source>Translators</source>
-        <translation>翻译人员</translation>
+        <translation>翻譯人員</translation>
     </message>
     <message>
         <source>French Translation:</source>
-        <translation>法语翻译：</translation>
+        <translation>法語翻譯：</translation>
     </message>
     <message>
         <source>German Translation:</source>
-        <translation>德语翻译：</translation>
+        <translation>德語翻譯：</translation>
     </message>
     <message>
         <source>Black Chocobo </source>
-        <translation>黑色陆行鸟 </translation>
+        <translation>黑色陸行鳥 </translation>
     </message>
     <message>
         <source>ff7tk: %1</source>
@@ -105,7 +105,7 @@ p, li { white-space: pre-wrap; }
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Ubuntu&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a href=&quot;https://github.com/sithlord48/blackchocobo&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#508ed8;&quot;&gt;项目页面&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a href=&quot;https://github.com/sithlord48/blackchocobo&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#508ed8;&quot;&gt;項目頁面&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
 </context>
 <context>
@@ -188,7 +188,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Sub</source>
-        <translation>潜水艇</translation>
+        <translation>潛水艇</translation>
     </message>
     <message>
         <source>X: </source>
@@ -200,23 +200,23 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Hour</source>
-        <translation>时</translation>
+        <translation>時</translation>
     </message>
     <message>
         <source>Misc</source>
-        <translation>杂项</translation>
+        <translation>雜項</translation>
     </message>
     <message>
         <source>None</source>
-        <translation>无</translation>
+        <translation>無</translation>
     </message>
     <message>
         <source>Slot</source>
-        <translation>存档位</translation>
+        <translation>存檔位</translation>
     </message>
     <message>
         <source>&amp;Edit</source>
-        <translation>&amp;编辑</translation>
+        <translation>&amp;編輯</translation>
     </message>
     <message>
         <source>&amp;File</source>
@@ -224,7 +224,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>&amp;Open</source>
-        <translation>&amp;打开</translation>
+        <translation>&amp;打開</translation>
     </message>
     <message>
         <source>&amp;Quit</source>
@@ -244,46 +244,46 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Spanish (PAL)</source>
-        <translation>西班牙语 (PAL)</translation>
+        <translation>西班牙語 (PAL)</translation>
     </message>
     <message>
         <source>&amp;Spanish (PAL)</source>
-        <translation>&amp;西班牙语 (PAL)</translation>
+        <translation>&amp;西班牙語 (PAL)</translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Resets
 When you Pass thru Battle Square&apos;s Door Set Location To &amp;quot;Arena
 Lobby&amp;quot; so you can spend
 them&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;当你通过战斗广场的门时，位置会重置为“竞技场大厅”，这样你就可以使用它们了&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;當你通過戰鬥廣場的門時，位置會重置為「競技場大廳」，這樣你就可以使用它們了&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>Add Each Materia to Stock (end of list)</source>
-        <translation>将每个魔晶石添加到库存（列表末尾）</translation>
+        <translation>將每個魔晶石添加到庫存（列表末尾）</translation>
     </message>
     <message>
         <source>Buggy</source>
-        <translation>越野车</translation>
+        <translation>越野車</translation>
     </message>
     <message>
         <source>Crazy Course</source>
-        <translation>疯狂赛道</translation>
+        <translation>瘋狂賽道</translation>
     </message>
     <message>
         <source>He&amp;lp</source>
-        <translation>帮&amp;助</translation>
+        <translation>幫&amp;助</translation>
     </message>
     <message>
         <source>Items</source>
-        <translation>物品</translation>
+        <translation>道具</translation>
     </message>
     <message>
         <source>Have Seen Pandora&apos;s Box</source>
-        <translation>已见过潘多拉之盒</translation>
+        <translation>已見過潘多拉之盒</translation>
     </message>
     <message>
         <source>Party</source>
-        <translation>队伍</translation>
+        <translation>隊伍</translation>
     </message>
     <message>
         <source>Other</source>
@@ -291,15 +291,15 @@ them&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
     </message>
     <message>
         <source>&amp;Place Leader</source>
-        <translation>&amp;放置队长</translation>
+        <translation>&amp;放置隊長</translation>
     </message>
     <message>
         <source>Show:</source>
-        <translation>显示：</translation>
+        <translation>顯示：</translation>
     </message>
     <message>
         <source>Time:</source>
-        <translation>时间：</translation>
+        <translation>時間：</translation>
     </message>
     <message>
         <source>angle</source>
@@ -311,139 +311,139 @@ them&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
     </message>
     <message>
         <source>Replay Mission</source>
-        <translation>重玩任务</translation>
+        <translation>重玩劇情</translation>
     </message>
     <message>
         <source> Played Video on Train?</source>
-        <translation> 在火车上播放过视频？</translation>
+        <translation> 在火車上播放過視頻？</translation>
     </message>
     <message>
         <source>Select Achievement File</source>
-        <translation>选择成就文件</translation>
+        <translation>選擇成就文件</translation>
     </message>
     <message>
         <source>Avalanche Has Run To Hideout</source>
-        <translation>雪崩已逃到藏身处</translation>
+        <translation>雪崩已逃到藏身處</translation>
     </message>
     <message numerus="yes">
         <source>Game Uses %n Save Block(s)</source>
         <translation>
-            <numerusform>游戏使用%n个存档块</numerusform>
+            <numerusform>遊戲使用%n個存檔塊</numerusform>
         </translation>
     </message>
     <message>
         <source>Coaster Shooter High Scores</source>
-        <translation>过山车射击游戏最高分</translation>
+        <translation>過山車射擊遊戲最高分</translation>
     </message>
     <message>
         <source>New Game Plus Created - Using: %1</source>
-        <translation>新存档+已创建 - 使用：%1</translation>
+        <translation>新存檔+已創建 - 使用：%1</translation>
     </message>
     <message>
         <source>Black Chocobo</source>
-        <translation>黑色陆行鸟</translation>
+        <translation>黑色陸行鳥</translation>
     </message>
     <message>
         <source>Black chocobo</source>
-        <translation>黑色陆行鸟</translation>
+        <translation>黑色陸行鳥</translation>
     </message>
     <message>
         <source>Apply Selected Replay </source>
-        <translation>应用所选重播</translation>
+        <translation>應用所選劇情</translation>
     </message>
     <message>
         <source>Export Successful</source>
-        <translation>导出成功</translation>
+        <translation>導出成功</translation>
     </message>
     <message>
         <source>&amp;French (PAL)</source>
-        <translation>&amp;法语 (PAL)</translation>
+        <translation>&amp;法語 (PAL)</translation>
     </message>
     <message>
         <source>This Will Copy Cloud as is to young cloud (caitsith&apos;s slot). Sephiroth&apos;s stats will come directly from the Default Save. Be Sure to back up your CaitSith and Vincent if you want to use them again</source>
-        <translation>这会将克劳德原样复制到年轻的克劳德（凯特西的存档位）。萨菲罗斯的属性将直接来自默认存档。如果你想再次使用凯特西和文森特，请务必备份他们</translation>
+        <translation>這會將當前克勞德的屬性復製到年輕的克勞德，薩菲羅斯的屬性將直接來自默認存檔。這將會占用凱特西和文森特的角色欄位置，如果你想再次使用凱特西和文森特，請務必備份他們</translation>
     </message>
     <message>
         <source>Import Canceled</source>
-        <translation>导入已取消</translation>
+        <translation>導入已取消</translation>
     </message>
     <message>
         <source>Midgar Train Flags</source>
-        <translation>米德加列车标记</translation>
+        <translation>米德加列車標記</translation>
     </message>
     <message>
         <source>Ultimate Weapons Hp</source>
-        <translation>究极武器生命值</translation>
+        <translation>究極神兵 HP</translation>
     </message>
     <message>
         <source>Turtle Paradise</source>
-        <translation>海龟天堂</translation>
+        <translation>龜道樂</translation>
     </message>
     <message>
         <source>Buggy / Highwind</source>
-        <translation>越野车 / 飞空艇</translation>
+        <translation>越野車 / 飛空艇</translation>
     </message>
     <message>
         <source>Create Cloud Save &amp;Folder</source>
-        <translation>创建云存档&amp;文件夹</translation>
+        <translation>創建雲存檔&amp;文件夾</translation>
     </message>
     <message>
         <source>Bombing Mission</source>
-        <translation>炸弹任务</translation>
+        <translation>爆破任務</translation>
     </message>
     <message>
         <source>Current Slot:%1</source>
-        <translation>当前存档位：%1</translation>
+        <translation>當前存檔位：%1</translation>
     </message>
     <message>
         <source>Selected Materia Skills and Stat Info</source>
-        <translation>所选魔晶石技能和属性信息</translation>
+        <translation>所選魔晶石技能和屬性信息</translation>
     </message>
     <message>
         <source>KeyItem</source>
-        <translation>关键物品</translation>
+        <translation>關鍵道具</translation>
     </message>
     <message>
         <source>Jessie Has Been Unstuck</source>
-        <translation>杰西已不再卡住</translation>
+        <translation>傑西已不再卡住</translation>
     </message>
     <message>
         <source>
   Next Data Chunk @ Slot:%1</source>
         <translation>
-  下一个数据块 @ 存档位：%1</translation>
+  下一個數據塊 @ 存檔位：%1</translation>
     </message>
     <message>
         <source>Party Leader</source>
-        <translation>队伍队长</translation>
+        <translation>隊伍隊長</translation>
     </message>
     <message>
         <source>Error Loading File %1</source>
-        <translation>加载文件%1时出错</translation>
+        <translation>加載文件%1時出錯</translation>
     </message>
     <message>
         <source>Talked to Biggs</source>
-        <translation>已和比格斯交谈</translation>
+        <translation>已和比格斯交談</translation>
     </message>
     <message>
         <source>&amp;Achievement Editor</source>
-        <translation>&amp;成就编辑器</translation>
+        <translation>&amp;成就編輯器</translation>
     </message>
     <message>
         <source>Game Options</source>
-        <translation>游戏选项</translation>
+        <translation>遊戲選項</translation>
     </message>
     <message>
         <source>&amp;About</source>
-        <translation>&amp;关于</translation>
+        <translation>&amp;關於</translation>
     </message>
     <message>
         <source>Sector 7 - Slums Progress</source>
-        <translation>第七区 - 贫民窟进度</translation>
+        <translation>第七區 - 貧民窟進度</translation>
     </message>
     <message>
         <source>Application Preferences</source>
-        <translation>应用程序偏好设置</translation>
+        <translation>應用程序偏好設置</translation>
     </message>
     <message>
         <source>Save Changes to the File:
@@ -453,16 +453,16 @@ them&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
     </message>
     <message>
         <source>-None-</source>
-        <translation>-无-</translation>
+        <translation>-無-</translation>
     </message>
     <message>
         <source>2nd Door Opened</source>
-        <translation>第二扇门已打开</translation>
+        <translation>第二扇門已打開</translation>
     </message>
     <message>
         <source>When Box is Partially Checked (&quot;-&quot;) it will
 trigger showing that tutorial</source>
-        <translation>当复选框被部分选中（&quot;-&quot;）时，它将触发显示该教程</translation>
+        <translation>當復選框被部分選中（&quot;-&quot;）時，它將觸發顯示該教程</translation>
     </message>
     <message>
         <source>Unknowns / Unused</source>
@@ -470,19 +470,19 @@ trigger showing that tutorial</source>
     </message>
     <message>
         <source>Destroy the Sector 5 Reactor </source>
-        <translation>摧毁第五区魔晄炉</translation>
+        <translation>摧毀五號魔晄爐</translation>
     </message>
     <message>
         <source>E&amp;xport Current Character</source>
-        <translation>导&amp;出当前角色</translation>
+        <translation>導&amp;出當前角色數據</translation>
     </message>
     <message>
         <source>Bombing Mission Progress</source>
-        <translation>炸弹任务进度</translation>
+        <translation>爆破任務進度</translation>
     </message>
     <message>
         <source>&amp;Copy Current Slot</source>
-        <translation>&amp;复制当前存档位</translation>
+        <translation>&amp;復製當前存檔位</translation>
     </message>
     <message>
         <source>Alt+Left</source>
@@ -490,7 +490,7 @@ trigger showing that tutorial</source>
     </message>
     <message>
         <source>Beat Ruby Weapon</source>
-        <translation>击败红宝石武器</translation>
+        <translation>擊敗紅寶石神兵</translation>
     </message>
     <message>
         <source>Materia</source>
@@ -498,19 +498,19 @@ trigger showing that tutorial</source>
     </message>
     <message>
         <source>Place &amp;Buggy/Highwind</source>
-        <translation>放置&amp;越野车/飞空艇</translation>
+        <translation>放置&amp;越野車/飛空艇</translation>
     </message>
     <message>
         <source>Battle Arena</source>
-        <translation>战斗竞技场</translation>
+        <translation>鬥技場</translation>
     </message>
     <message>
         <source>Sa&amp;ve As</source>
-        <translation>另&amp;存为</translation>
+        <translation>另&amp;存為</translation>
     </message>
     <message>
         <source>Buggy/Highwind</source>
-        <translation>越野车/飞空艇</translation>
+        <translation>越野車/飛空艇</translation>
     </message>
     <message>
         <source>Remove ALL Materia </source>
@@ -518,15 +518,15 @@ trigger showing that tutorial</source>
     </message>
     <message>
         <source>Have Won the Submarine Game</source>
-        <translation>已赢得潜水艇小游戏</translation>
+        <translation>已贏得潛水艇小遊戲</translation>
     </message>
     <message>
         <source>Party leader</source>
-        <translation>队伍队长</translation>
+        <translation>隊伍隊長</translation>
     </message>
     <message>
         <source>Avalanche had meeting after Bombing Mission</source>
-        <translation>炸弹任务后雪崩开会</translation>
+        <translation>爆破任務後雪崩開會</translation>
     </message>
     <message>
         <source>Ctrl+Shift+Ins</source>
@@ -538,7 +538,7 @@ trigger showing that tutorial</source>
     </message>
     <message>
         <source>Load Failed</source>
-        <translation>加载失败</translation>
+        <translation>加載失敗</translation>
     </message>
     <message>
         <source>Ctrl+E</source>
@@ -554,7 +554,7 @@ trigger showing that tutorial</source>
     </message>
     <message>
         <source>Hex Editor</source>
-        <translation>十六进制编辑器</translation>
+        <translation>十六進製編輯器</translation>
     </message>
     <message>
         <source>&amp;Configure</source>
@@ -562,35 +562,35 @@ trigger showing that tutorial</source>
     </message>
     <message>
         <source>Funds </source>
-        <translation>资金</translation>
+        <translation>資金</translation>
     </message>
     <message>
         <source>Fort Condor</source>
-        <translation>秃鹰堡垒</translation>
+        <translation>禿鷲要塞</translation>
     </message>
     <message>
         <source>German (PAL)</source>
-        <translation>德语 (PAL)</translation>
+        <translation>德語 (PAL)</translation>
     </message>
     <message>
         <source>Aeris Death</source>
-        <translation>爱丽丝之死</translation>
+        <translation>愛麗絲之死</translation>
     </message>
     <message>
         <source>Unlocked Yuffie </source>
-        <translation>已解锁尤菲</translation>
+        <translation>已解鎖尤菲</translation>
     </message>
     <message>
         <source>Talked to Wedge Twice</source>
-        <translation>已和威吉交谈两次</translation>
+        <translation>已和威吉交談兩次</translation>
     </message>
     <message>
         <source>Place &amp;Wild Chocobo</source>
-        <translation>放置&amp;野陆行鸟</translation>
+        <translation>放置&amp;野陸行鳥</translation>
     </message>
     <message>
         <source>Master</source>
-        <translation>大师</translation>
+        <translation>最高等級</translation>
     </message>
     <message>
         <source>Love Points</source>
@@ -598,19 +598,19 @@ trigger showing that tutorial</source>
     </message>
     <message>
         <source>Time Played</source>
-        <translation>游玩时间</translation>
+        <translation>遊玩時間</translation>
     </message>
     <message>
         <source>Post Pan NMKIN_5</source>
-        <translation>平移后 NMKIN_5</translation>
+        <translation>平移後 NMKIN_5</translation>
     </message>
     <message>
         <source>Can Fight Mystery Ninja in Forests</source>
-        <translation>可以在森林中与神秘忍者战斗</translation>
+        <translation>可以在森林中與神秘忍者戰鬥</translation>
     </message>
     <message>
         <source>Points</source>
-        <translation>点数</translation>
+        <translation>點數</translation>
     </message>
     <message>
         <source>Location</source>
@@ -622,43 +622,43 @@ trigger showing that tutorial</source>
     </message>
     <message>
         <source>Error Importing Slot %1</source>
-        <translation>导入存档槽 %1 时出错</translation>
+        <translation>導入存檔槽 %1 時出錯</translation>
     </message>
     <message>
         <source>Event Progress</source>
-        <translation>事件进度</translation>
+        <translation>事件進度</translation>
     </message>
     <message>
         <source>&lt;------Left Table------
 Select Unknown Var To View
 Table Entries are Editable</source>
-        <translation>&lt;------左侧表格------
-选择未知变量查看
-表格条目可编辑</translation>
+        <translation>&lt;------左側表格------
+選擇未知變量查看
+表格條目可編輯</translation>
     </message>
     <message>
         <source>Sector 7 Trainstation</source>
-        <translation>第七区火车站</translation>
+        <translation>第七區火車站</translation>
     </message>
     <message>
         <source>Game Region</source>
-        <translation>游戏区域</translation>
+        <translation>遊戲區域</translation>
     </message>
     <message>
         <source>Yellow chocobo</source>
-        <translation>黄色陆行鸟</translation>
+        <translation>黃色陸行鳥</translation>
     </message>
     <message>
         <source>&amp;Japanese (NTSC-J)</source>
-        <translation>&amp;日语 (NTSC-J)</translation>
+        <translation>&amp;日語 (NTSC-J)</translation>
     </message>
     <message>
         <source>Diamond / Ultimate / Ruby Weapon</source>
-        <translation>钻石/究极/红宝石武器</translation>
+        <translation>鉆石/究極/紅寶石神兵</translation>
     </message>
     <message>
         <source>Uk &amp;English (PAL)</source>
-        <translation>英国&amp;英语 (PAL)</translation>
+        <translation>英國&amp;英語 (PAL)</translation>
     </message>
     <message>
         <source>Save FF7 Character File</source>
@@ -666,56 +666,56 @@ Table Entries are Editable</source>
     </message>
     <message>
         <source>Snowboard Mini Game </source>
-        <translation>滑雪小游戏</translation>
+        <translation>滑雪小遊戲</translation>
     </message>
     <message>
         <source>Initial Settings</source>
-        <translation>初始设置</translation>
+        <translation>初始設置</translation>
     </message>
     <message>
         <source>Special Battle Wins</source>
-        <translation>特殊战斗胜利次数</translation>
+        <translation>特殊戰鬥勝利次數</translation>
     </message>
     <message>
         <source>UK English (PAL)</source>
-        <translation>英国英语 (PAL)</translation>
+        <translation>英國英語 (PAL)</translation>
     </message>
     <message>
         <source>===Empty Slot===</source>
-        <translation>===空槽===</translation>
+        <translation>===空===</translation>
     </message>
     <message>
         <source>Right click on map to easily set an item&apos;s
 location.</source>
-        <translation>右键点击地图可轻松设置物品位置。</translation>
+        <translation>右鍵點擊地圖可輕松放置。</translation>
     </message>
     <message>
         <source>Exported Slot:%2 from %1 -&gt; %3</source>
-        <translation>已导出存档槽：%2 从 %1 -&gt; %3</translation>
+        <translation>已導出存檔槽：%2 從 %1 -&gt; %3</translation>
     </message>
     <message>
         <source>Tiny bronco</source>
-        <translation>飞机</translation>
+        <translation>飛機</translation>
     </message>
     <message>
         <source>Cleared All Items</source>
-        <translation>已清除所有物品</translation>
+        <translation>已清除所有道具</translation>
     </message>
     <message>
         <source>Battle Love Points</source>
-        <translation>战斗好感度</translation>
+        <translation>戰鬥好感度</translation>
     </message>
     <message>
         <source>Game Progress</source>
-        <translation>游戏进度</translation>
+        <translation>遊戲進度</translation>
     </message>
     <message>
         <source>Post Pan MD8_2</source>
-        <translation>平移后 MD8_2</translation>
+        <translation>平移後 MD8_2</translation>
     </message>
     <message>
         <source>Place &amp;Diamond/Ultimate/Ruby Weapon</source>
-        <translation>放置&amp;钻石/究极/红宝石武器</translation>
+        <translation>放置&amp;鉆石/究極/紅寶石神兵</translation>
     </message>
     <message>
         <source>Alt+Right</source>
@@ -723,79 +723,79 @@ location.</source>
     </message>
     <message>
         <source>Japanese (NTSC-J)</source>
-        <translation>日语 (NTSC-J)</translation>
+        <translation>日語 (NTSC-J)</translation>
     </message>
     <message>
         <source>Saving on the World Map</source>
-        <translation>世界地图存档</translation>
+        <translation>世界地圖存檔</translation>
     </message>
     <message>
         <source>TinyBronco/Chocobo</source>
-        <translation>迷你飞空艇/陆行鸟</translation>
+        <translation>飛機/陸行鳥</translation>
     </message>
     <message>
         <source>&amp;Slot Region</source>
-        <translation>&amp;存档槽区域</translation>
+        <translation>&amp;存檔槽區域</translation>
     </message>
     <message>
         <source>Save Error</source>
-        <translation>保存错误</translation>
+        <translation>保存錯誤</translation>
     </message>
     <message>
         <source>&amp;Import To Current Slot</source>
-        <translation>&amp;导入到当前存档槽</translation>
+        <translation>&amp;導入到當前存檔槽</translation>
     </message>
     <message>
         <source>Green chocobo</source>
-        <translation>绿色陆行鸟</translation>
+        <translation>綠色陸行鳥</translation>
     </message>
     <message>
         <source>Talked to Jessie Before Looking At Map</source>
-        <translation>看地图前与杰西对话</translation>
+        <translation>看地圖前與傑西對話</translation>
     </message>
     <message>
         <source>
  End Of Linked Data</source>
         <translation>
- 链接数据结束</translation>
+ 鏈接數據結束</translation>
     </message>
     <message>
         <source>------Right Table------&gt;
 Select A Slot To Compare
 Table is Read Only
 Var And Scrolling Synced To Left Table</source>
-        <translation>------右侧表格------&gt;
-选择一个存档槽进行比较
-表格只读
-变量和滚动与左侧表格同步</translation>
+        <translation>------右側表格------&gt;
+選擇一個存檔槽進行比較
+表格只讀
+變量和滾動與左側表格同步</translation>
     </message>
     <message>
         <source>Talked To Trainman 3 times</source>
-        <translation>与列车员对话3次</translation>
+        <translation>與列車員對話3次</translation>
     </message>
     <message>
         <source>Select A File to Save As</source>
-        <translation>选择要保存的文件</translation>
+        <translation>選擇要保存的文件</translation>
     </message>
     <message>
         <source>Map Id: </source>
-        <translation>地图ID: </translation>
+        <translation>地圖ID: </translation>
     </message>
     <message>
         <source>Export Failed</source>
-        <translation>导出失败</translation>
+        <translation>導出失敗</translation>
     </message>
     <message>
         <source>New Game Created - Using: %1</source>
-        <translation>新存档已创建 - 使用：%1</translation>
+        <translation>新存檔已創建 - 使用：%1</translation>
     </message>
     <message>
         <source>Clear All Stolen Materia</source>
-        <translation>清除所有被盗魔晶石</translation>
+        <translation>清除所有被盜魔晶石</translation>
     </message>
     <message>
         <source>Place &amp;Tiny Bronco/Chocobo</source>
-        <translation>放置&amp;飞机/陆行鸟</translation>
+        <translation>放置&amp;飛機/陸行鳥</translation>
     </message>
     <message>
         <source>All Materia Added!</source>
@@ -803,197 +803,197 @@ Var And Scrolling Synced To Left Table</source>
     </message>
     <message>
         <source>Controling the Sub</source>
-        <translation>控制潜水艇</translation>
+        <translation>控製潛水艇</translation>
     </message>
     <message>
         <source>Expert Course</source>
-        <translation>专家级赛道</translation>
+        <translation>專家級賽道</translation>
     </message>
     <message>
         <source>The Plate is Falling</source>
-        <translation>板块正在坠落</translation>
+        <translation>圓盤正在墜落</translation>
     </message>
     <message>
         <source>ChurchProgress</source>
-        <translation>教堂进度</translation>
+        <translation>教堂進度</translation>
     </message>
     <message>
         <source>Main Progression</source>
-        <translation>主线进度</translation>
+        <translation>主線進度</translation>
     </message>
     <message>
         <source>Imported %1 -&gt; Slot:%2</source>
-        <translation>已导入 %1 -&gt; 存档槽：%2</translation>
+        <translation>已導入 %1 -&gt; 存檔槽：%2</translation>
     </message>
     <message>
         <source>Select FF7 Character Stat File</source>
-        <translation>选择FF7角色状态文件</translation>
+        <translation>選擇FF7角色數據文件</translation>
     </message>
     <message>
         <source>Record </source>
-        <translation>记录 </translation>
+        <translation>記錄 </translation>
     </message>
     <message>
         <source>Post Pillar Pan Video</source>
-        <translation>柱子平移视频后</translation>
+        <translation>柱子平移視頻後</translation>
     </message>
     <message>
         <source>&amp;Select Slot</source>
-        <translation>&amp;选择存档槽</translation>
+        <translation>&amp;選擇存檔槽</translation>
     </message>
     <message>
         <source>Tiny Bronco / Chocobo</source>
-        <translation>飞机 / 陆行鸟</translation>
+        <translation>飛機 / 陸行鳥</translation>
     </message>
     <message>
         <source>Played piano during flashback</source>
-        <translation>回忆中弹奏了钢琴</translation>
+        <translation>回憶中彈奏了鋼琴</translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Number of wins for the &amp;quot;Special Battle&amp;quot;. Mini-Game Reward is based on number of wins.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;“特殊战斗”的胜利次数。小游戏奖励基于胜利次数。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;「特殊戰鬥」的勝利次數。小遊戲獎勵基於勝利次數。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>The Bomb Was Set</source>
-        <translation>炸弹已放置</translation>
+        <translation>炸彈已放置</translation>
     </message>
     <message>
         <source>DonProgress</source>
-        <translation>唐进度</translation>
+        <translation>唐進度</translation>
     </message>
     <message>
         <source>The Date Scene</source>
-        <translation>约会场景</translation>
+        <translation>約會場景</translation>
     </message>
     <message>
         <source>International (NTSC-J)</source>
-        <translation>国际版 (NTSC-J)</translation>
+        <translation>國際版 (NTSC-J)</translation>
     </message>
     <message>
         <source>Unlocked Vincent</source>
-        <translation>已解锁文森特</translation>
+        <translation>已解鎖文森特</translation>
     </message>
     <message>
         <source>Party&apos;s Materia Stock</source>
-        <translation>队伍的魔晶石存量</translation>
+        <translation>隊伍的魔晶石</translation>
     </message>
     <message>
         <source>&amp;International (NTSC-J)</source>
-        <translation>&amp;国际版 (NTSC-J)</translation>
+        <translation>&amp;國際版 (NTSC-J)</translation>
     </message>
     <message>
         <source>Place &amp;Sub</source>
-        <translation>放置&amp;潜水艇</translation>
+        <translation>放置&amp;潛水艇</translation>
     </message>
     <message>
         <source>Unknown Var:</source>
-        <translation>未知变量：</translation>
+        <translation>未知變量：</translation>
     </message>
     <message>
         <source>Unknown Vars</source>
-        <translation>未知变量</translation>
+        <translation>未知變量</translation>
     </message>
     <message>
         <source>Elevator Door Open</source>
-        <translation>电梯门已开</translation>
+        <translation>電梯門已開</translation>
     </message>
     <message>
         <source>Failed to save file
 %1</source>
-        <translation>保存文件失败
+        <translation>保存文件失敗
 %1</translation>
     </message>
     <message>
         <source>Replay the bombing mission from right after you get off the train.</source>
-        <translation>重玩下火车后的炸弹任务。</translation>
+        <translation>下火車後的爆破任務。</translation>
     </message>
     <message>
         <source>Chocobo</source>
-        <translation>陆行鸟</translation>
+        <translation>陸行鳥</translation>
     </message>
     <message>
         <source>%1:
 %2 is Not a FF7 Character Stat File.</source>
         <translation>%1:
-%2 不是一个FF7角色状态文件。</translation>
+%2 不是一個FF7角色數據文件。</translation>
     </message>
     <message>
         <source>PSX Save Data</source>
-        <translation>PSX存档数据</translation>
+        <translation>PSX存檔數據</translation>
     </message>
     <message>
         <source>The Church In The Slums</source>
-        <translation>贫民窟的教堂</translation>
+        <translation>貧民窟的教堂</translation>
     </message>
     <message>
         <source>
  Mid-Linked Block </source>
         <translation>
- 中间链接块</translation>
+ 中間鏈接塊</translation>
     </message>
     <message>
         <source>Field Location</source>
-        <translation>野外位置</translation>
+        <translation>場景位置</translation>
     </message>
     <message>
         <source>&#xa0; &#xa0; &#xa0; &#xa0; &#xa0;INFO ON CURRENTLY SELECTED REPLAY MISSION</source>
-        <translation type="vanished">&#xa0; &#xa0; &#xa0; &#xa0; &#xa0;当前选择的重玩任务信息</translation>
+        <translation type="vanished">&#xa0; &#xa0; &#xa0; &#xa0; &#xa0;選擇要重玩的劇情</translation>
     </message>
     <message>
         <source>&amp;Paste Slot</source>
-        <translation>&amp;粘贴存档槽</translation>
+        <translation>&amp;粘貼存檔槽</translation>
     </message>
     <message>
         <source>Test Data</source>
-        <translation>测试数据</translation>
+        <translation>測試數據</translation>
     </message>
     <message>
         <source>Progression Reset Complete</source>
-        <translation>进度重置完成</translation>
+        <translation>進度重置完成</translation>
     </message>
     <message>
         <source>New &amp;Game+ </source>
-        <translation>新&amp;游戏+ </translation>
+        <translation>新&amp;遊戲+ </translation>
     </message>
     <message>
         <source>Pair At Station agree</source>
-        <translation>车站情侣同意</translation>
+        <translation>車站情侶同意</translation>
     </message>
     <message>
         <source>Beginner Course</source>
-        <translation>初级赛道</translation>
+        <translation>初級賽道</translation>
     </message>
     <message>
         <source>US English (NTSC-U)</source>
-        <translation>美国英语 (NTSC-U)</translation>
+        <translation>美國英語 (NTSC-U)</translation>
     </message>
     <message>
         <source>Diamond / Ultimate / Ruby&#xa0; Weapon</source>
-        <translation type="vanished">钻石/究极/红宝石 武器</translation>
+        <translation type="vanished">鉆石/究極/紅寶石 神兵</translation>
     </message>
     <message>
         <source>PsxName:</source>
-        <translation>Psx名称：</translation>
+        <translation>Psx名稱：</translation>
     </message>
     <message>
         <source>&amp;German (PAL)</source>
-        <translation>&amp;德语 (PAL)</translation>
+        <translation>&amp;德語 (PAL)</translation>
     </message>
     <message>
         <source>Meeting Aeris</source>
-        <translation>遇见爱丽丝</translation>
+        <translation>遇見愛麗絲</translation>
     </message>
     <message>
         <source>Disc&#xa0; #</source>
-        <translation type="vanished">光盘号</translation>
+        <translation type="vanished">光盤  #</translation>
     </message>
     <message>
         <source>All Items Added</source>
-        <translation>所有物品已添加</translation>
+        <translation>所有道具已添加</translation>
     </message>
     <message>
         <source>Playstation Save Info</source>
-        <translation>Playstation存档信息</translation>
+        <translation>Playstation存檔信息</translation>
     </message>
     <message>
         <source>G-Bike High Score</source>
@@ -1001,7 +1001,7 @@ Var And Scrolling Synced To Left Table</source>
     </message>
     <message>
         <source>&amp;Reload</source>
-        <translation>&amp;重新加载</translation>
+        <translation>&amp;重新加載</translation>
     </message>
     <message>
         <source>Ctrl+Ins</source>
@@ -1009,93 +1009,93 @@ Var And Scrolling Synced To Left Table</source>
     </message>
     <message>
         <source>No Description Text</source>
-        <translation>无描述文本</translation>
+        <translation>無描述文本</translation>
     </message>
     <message>
         <source>Number of Steps</source>
-        <translation>步数</translation>
+        <translation>步數</translation>
     </message>
     <message>
         <source>&amp;Previous Slot</source>
-        <translation>&amp;上一个存档槽</translation>
+        <translation>&amp;上一個存檔槽</translation>
     </message>
     <message>
         <source>Barret called us</source>
-        <translation>巴雷特呼叫我们</translation>
+        <translation>巴雷特呼叫我們</translation>
     </message>
     <message>
         <source>Countdown Timer</source>
-        <translation>倒计时器</translation>
+        <translation>倒計時器</translation>
     </message>
     <message>
         <source>Wild Chocobo</source>
-        <translation>野生陆行鸟</translation>
+        <translation>野生陸行鳥</translation>
     </message>
     <message>
         <source>Wild chocobo</source>
-        <translation>野生陆行鸟</translation>
+        <translation>野生陸行鳥</translation>
     </message>
     <message>
         <source>(Deleted)</source>
-        <translation>(已删除)</translation>
+        <translation>(已刪除)</translation>
     </message>
     <message>
         <source>Failed to Load File</source>
-        <translation>加载文件失败</translation>
+        <translation>加載文件失敗</translation>
     </message>
     <message>
         <source>Character Export Successful</source>
-        <translation>角色导出成功</translation>
+        <translation>角色導出成功</translation>
     </message>
     <message>
         <source>Replay the Date Scene, Your Location will be set To The Ropeway Station Talk to man by the Tram to start event. If Your Looking for a special Date be sure to set your love points too.</source>
-        <translation>重玩约会场景，你的位置将被设置为缆车站。与电车旁的人对话开始事件。如果你正在寻找一个特别的约会，请务必设置你的好感度。</translation>
+        <translation>你的位置將被設置為觀光纜車站。與電車旁的人對話開始事件。如果你正在尋找一個特別的約會，請務必設置你的好感度。</translation>
     </message>
     <message>
         <source>Imported Slot:%2 from %1 -&gt; Slot:%3</source>
-        <translation>已导入存档槽：%2 从 %1 -&gt; 存档槽：%3</translation>
+        <translation>已導入存檔槽：%2 從 %1 -&gt; 存檔槽：%3</translation>
     </message>
     <message>
         <source>Save Slot</source>
-        <translation>存档槽</translation>
+        <translation>存檔槽</translation>
     </message>
     <message>
         <source>Cannot read file %1:
     %2.</source>
-        <translation type="vanished">无法读取文件 %1:
+        <translation type="vanished">無法讀取文件 %1:
     %2。</translation>
     </message>
     <message>
         <source>&amp;New Game</source>
-        <translation>&amp;新存档</translation>
+        <translation>&amp;新存檔</translation>
     </message>
     <message>
         <source>Builtin Data</source>
-        <translation>内置数据</translation>
+        <translation>內置數據</translation>
     </message>
     <message>
         <source>Set Replay Mission below to set the game back to that mission. This will automatically set your save location and disc # as well as Quest Progression vars. DO NOT OVERWRITE YOUR CURRENT SAVE when using this feature; I cannot promise that you will be able to play from any replay until the end of the game, or that any given replay will work in your save. This feature is still under development.</source>
-        <translation>在下方设置重玩任务，将游戏恢复到该任务。这将自动设置你的存档位置、光盘号以及任务进度变量。使用此功能时，请勿覆盖你当前的存档；我无法保证你能够从任何的重玩任务一直玩到游戏结束，或许所有的重玩任务都能在你的存档中正常工作。此功能仍在开发中。</translation>
+        <translation>在下方設置重玩劇情，將遊戲恢復到該劇情。這將自動設置你的存檔位置、光盤號以及劇情進度變量。使用此功能時，請勿覆蓋你當前的存檔；我無法保證你所選的劇情一直玩到遊戲結束，或許所有的重玩劇情都能在你的存檔中正常工作。此功能仍在開發中。</translation>
     </message>
     <message>
         <source>&amp;Settings</source>
-        <translation>&amp;设置</translation>
+        <translation>&amp;設置</translation>
     </message>
     <message>
         <source>&amp;Us English (NTSC-U)</source>
-        <translation>&amp;美国英语 (NTSC-U)</translation>
+        <translation>&amp;美國英語 (NTSC-U)</translation>
     </message>
     <message>
         <source>Talked To soldier two times</source>
-        <translation>与士兵对话两次</translation>
+        <translation>與士兵對話兩次</translation>
     </message>
     <message>
         <source>Clea&amp;r Slot</source>
-        <translation>清&amp;除存档槽</translation>
+        <translation>清&amp;除存檔槽</translation>
     </message>
     <message>
         <source>Gold chocobo</source>
-        <translation>金色陆行鸟</translation>
+        <translation>金色陸行鳥</translation>
     </message>
     <message>
         <source>Ctrl+Shift+=</source>
@@ -1119,27 +1119,27 @@ Var And Scrolling Synced To Left Table</source>
     </message>
     <message>
         <source>Blue chocobo</source>
-        <translation>蓝色陆行鸟</translation>
+        <translation>藍色陸行鳥</translation>
     </message>
     <message>
         <source>Replay the death of Aeris.This option Will remove Aeris from your PHS</source>
-        <translation>重玩爱丽丝之死。此选项将从你的PHS中移除爱丽丝</translation>
+        <translation>此選項將從你的PHS中移除愛麗絲</translation>
     </message>
     <message>
         <source>Can Show Pillar Pan Video</source>
-        <translation>可以显示柱子平移视频</translation>
+        <translation>可以顯示柱子平移視頻</translation>
     </message>
     <message>
         <source>Open Final Fantasy 7 Save</source>
-        <translation>打开最终幻想7存档</translation>
+        <translation>打開最終幻想7存檔</translation>
     </message>
     <message>
         <source>Set Save Location: %1</source>
-        <translation>设置保存位置：%1</translation>
+        <translation>設置保存位置：%1</translation>
     </message>
     <message>
         <source>Battle Points</source>
-        <translation>战斗点数</translation>
+        <translation>戰鬥點數</translation>
     </message>
     <message>
         <source>Dat File (*.dat)</source>
@@ -1147,19 +1147,19 @@ Var And Scrolling Synced To Left Table</source>
     </message>
     <message>
         <source>Cloud&apos;s Flashback</source>
-        <translation>克劳德的回忆</translation>
+        <translation>克勞德的回憶</translation>
     </message>
     <message>
         <source>Set To Reactor 5 Mode</source>
-        <translation>设置为反应炉5模式</translation>
+        <translation>設置為五號魔晄爐模式</translation>
     </message>
     <message>
         <source>Bombing Mission Start Flag</source>
-        <translation>炸弹任务开始标记</translation>
+        <translation>爆破任務開始標記</translation>
     </message>
     <message>
         <source>Beat Emerald Weapon</source>
-        <translation>击败绿宝石武器</translation>
+        <translation>擊敗綠寶石神兵</translation>
     </message>
     <message>
         <source>Materia Stolen By Yuffie</source>
@@ -1167,185 +1167,186 @@ Var And Scrolling Synced To Left Table</source>
     </message>
     <message>
         <source>Global Progress</source>
-        <translation>全局进度</translation>
+        <translation>全局進度</translation>
     </message>
     <message>
         <source>1st Door Open</source>
-        <translation>第一扇门已开</translation>
+        <translation>第一扇門已開</translation>
     </message>
     <message>
         <source>French (PAL)</source>
-        <translation>法语 (PAL)</translation>
+        <translation>法語 (PAL)</translation>
     </message>
     <message>
         <source>Visible On World Map</source>
-        <translation>在世界地图上可见</translation>
+        <translation>在世界地圖上可見</translation>
     </message>
     <message>
         <source>Worldmap Location</source>
-        <translation>世界地图位置</translation>
+        <translation>世界地圖位置</translation>
     </message>
     <message>
         <source>Cait Sith and Vincent should not be enabled if they are disabled in the Party tab.</source>
-        <translation>如果凯特西和文森特在队伍标签页中被禁用，则不应在此处启用。</translation>
+        <translation>如果凱特西和文森特在隊伍標簽頁中被禁用，則不應在此處啟用。</translation>
     </message>
     <message>
         <source>Save Point Location In North Crater</source>
-        <translation>大空洞存档点位置</translation>
+        <translation>大空洞存檔點位置</translation>
     </message>
     <message>
         <source>Trigger Game Over (countdown reached 0)</source>
-        <translation>触发游戏结束（倒计时归零）</translation>
+        <translation>觸發遊戲結束（倒計時歸零）</translation>
     </message>
     <message>
         <source>Post Electrical Effect MD8_3</source>
-        <translation>电效应后 MD8_3</translation>
+        <translation>電效應後 MD8_3</translation>
     </message>
     <message>
         <source>I&amp;mport Current Character</source>
-        <translation>导&amp;入当前角色</translation>
+        <translation>導&amp;入當前角色數據</translation>
     </message>
     <message>
         <source>sliders show </source>
-        <translation>滑块显示 </translation>
+        <translation>滑塊顯示 </translation>
     </message>
     <message>
         <source>Escape From Reactor </source>
-        <translation>逃离反应炉 </translation>
+        <translation>逃離反應爐 </translation>
     </message>
     <message>
         <source>&amp;Next Slot</source>
-        <translation>&amp;下一个存档槽</translation>
+        <translation>&amp;下一個存檔槽</translation>
     </message>
     <message>
         <source>Compare To Slot</source>
-        <translation>与存档槽比较</translation>
+        <translation>與存檔槽比較</translation>
     </message>
     <message>
         <source>FF7 Character Stat File(*.char)</source>
-        <translation>FF7角色状态文件(*.char)</translation>
+        <translation>FF7角色數據文件(*.char)</translation>
     </message>
     <message>
         <source>Character Export Failed</source>
-        <translation>角色导出失败</translation>
+        <translation>角色導出失敗</translation>
     </message>
     <message>
         <source>Sector 7 Pillar</source>
-        <translation>第七区支柱</translation>
+        <translation>第七區支柱</translation>
     </message>
     <message>
         <source>Highwind</source>
-        <translation>飞空艇</translation>
+        <translation>飛空艇</translation>
     </message>
     <message>
         <source>Tutorials Seen</source>
-        <translation>已看过的教程</translation>
+        <translation>已看過的教程</translation>
     </message>
     <message>
         <source>Elevator On 2nd Floor</source>
-        <translation>电梯在二楼</translation>
+        <translation>電梯在二樓</translation>
     </message>
     <message>
         <source>Diamond / Ultimate / Ruby  Weapon</source>
-        <translation type="unfinished">钻石/究极/红宝石 武器</translation>
+        <translation>鉆石/究極/紅寶石 神兵</translation>
     </message>
     <message>
         <source>Disc  #</source>
-        <translation type="unfinished"></translation>
+        <translation>光盤  #</translation>
     </message>
     <message>
         <source>Cannot read file %1:
 %2.</source>
-        <translation type="unfinished"></translation>
+        <translation>無法讀取文件 %1:
+%2.</translation>
     </message>
     <message>
         <source>         INFO ON CURRENTLY SELECTED REPLAY MISSION</source>
-        <translation type="unfinished"></translation>
+        <translation>選擇要重玩的劇情</translation>
     </message>
 </context>
 <context>
     <name>ItemTab</name>
     <message>
         <source>GP</source>
-        <translation>陆行鸟点数</translation>
+        <translation>GP</translation>
     </message>
     <message>
         <source>Gil</source>
-        <translation>金钱</translation>
+        <translation>金錢</translation>
     </message>
     <message>
         <source>Money</source>
-        <translation>金钱</translation>
+        <translation>金錢</translation>
     </message>
     <message>
         <source>Unused KeyItems</source>
-        <translation>未使用的关键物品</translation>
+        <translation>未使用的關鍵道具</translation>
     </message>
     <message>
         <source>Add Max of All Items</source>
-        <translation>添加所有物品最大数量</translation>
+        <translation>添加所有道具最大數量</translation>
     </message>
     <message>
         <source>Clear All Items</source>
-        <translation>清除所有物品</translation>
+        <translation>清除所有道具</translation>
     </message>
     <message>
         <source>Battles</source>
-        <translation>战斗次数</translation>
+        <translation>戰鬥次數</translation>
     </message>
     <message>
         <source>Search For &quot;KeyItem&quot; using item search mode on the location tab</source>
-        <translation>在位置标签页使用物品搜索模式搜索“关键物品”</translation>
+        <translation>跳轉到「位置「標簽頁搜索「關鍵道具」</translation>
     </message>
     <message>
         <source>Escapes</source>
-        <translation>逃跑次数</translation>
+        <translation>逃跑次數</translation>
     </message>
     <message>
         <source>Inventory</source>
-        <translation>物品栏</translation>
+        <translation>道具欄</translation>
     </message>
     <message>
         <source>KeyItems</source>
-        <translation>关键物品</translation>
+        <translation>關鍵道具</translation>
     </message>
     <message>
         <source>Mystery panties</source>
-        <translation>神秘内裤</translation>
+        <translation>神秘的內褲</translation>
     </message>
     <message>
         <source>Letter to a Wife</source>
-        <translation>给妻子的信</translation>
+        <translation>給妻子的信</translation>
     </message>
     <message>
         <source>Turtle Paradise Flyers Collected</source>
-        <translation>已收集的海龟天堂传单</translation>
+        <translation>龜道樂宣傳單收集</translation>
     </message>
     <message>
         <source>Letter to a Daughter</source>
-        <translation>给女儿的信</translation>
+        <translation>給女兒的信</translation>
     </message>
     <message>
         <source>Search for &quot;Turtle Paradise&quot; using item search mode on the location tab</source>
-        <translation>在位置标签页使用物品搜索模式搜索“海龟天堂”</translation>
+        <translation>跳轉到「位置「標簽頁搜索「龜道樂」</translation>
     </message>
 </context>
 <context>
     <name>MainWindow</name>
     <message>
         <source>TRANSLATE TO YOUR LANGUAGE NAME</source>
-        <translation>简体中文</translation>
+        <translation>簡體中文</translation>
     </message>
 </context>
 <context>
     <name>Options</name>
     <message>
         <source>Save</source>
-        <translation>存档</translation>
+        <translation>存檔</translation>
     </message>
     <message>
         <source>CharEditor - Simulate Leveling Up / Down</source>
-        <translation>角色编辑器 - 模拟升级/降级</translation>
+        <translation>角色編輯器 - 模擬升級/降級</translation>
     </message>
     <message>
         <source>PAL-E</source>
@@ -1353,23 +1354,23 @@ Var And Scrolling Synced To Left Table</source>
     </message>
     <message>
         <source>Paths</source>
-        <translation>路径</translation>
+        <translation>路徑</translation>
     </message>
     <message>
         <source>Select A Default Save Game (Must Be Raw PSX)</source>
-        <translation>选择一个默认存档（必须是原始PSX格式）</translation>
+        <translation>選擇一個默認存檔（必須是原始PSX格式）</translation>
     </message>
     <message>
         <source>Override Builtin New Game Data</source>
-        <translation>覆盖内置新存档数据</translation>
+        <translation>覆蓋內置新存檔數據</translation>
     </message>
     <message>
         <source>Item Editor - Always Cap Quantity to 99</source>
-        <translation>物品编辑器 - 始终将数量上限设为99</translation>
+        <translation>道具編輯器 - 始終將數量上限設為99</translation>
     </message>
     <message>
         <source>Default Path For Loading All Saves</source>
-        <translation>加载所有存档的默认路径</translation>
+        <translation>加載所有存檔的默認文件夾路徑</translation>
     </message>
     <message>
         <source>NTSC-JI</source>
@@ -1377,27 +1378,27 @@ Var And Scrolling Synced To Left Table</source>
     </message>
     <message>
         <source>Chocobo Manager - Show Pcount / Personality</source>
-        <translation>陆行鸟管理器 - 显示P计数/个性</translation>
+        <translation>陸行鳥管理器 - 顯示P計數/個性</translation>
     </message>
     <message>
         <source>Path For PC (.ff7) Saves</source>
-        <translation>PC (.ff7) 存档路径</translation>
+        <translation>PC (.ff7) 存檔文件夾路徑</translation>
     </message>
     <message>
         <source>World Map Viewer- Show int SpinBoxes for Leader ID and buggy ID</source>
-        <translation>世界地图查看器 - 显示队长ID和越野车ID的整数微调框</translation>
+        <translation>世界地圖查看器 - 顯示隊長ID和越野車ID的整數微調框</translation>
     </message>
     <message>
         <source>Editable Combo for Materia and Items</source>
-        <translation>魔晶石和物品的可编辑组合框</translation>
+        <translation>魔晶石和道具的可編輯組合框</translation>
     </message>
     <message>
         <source>Create A Backup when Overwriting a file</source>
-        <translation>覆盖文件时创建备份</translation>
+        <translation>覆蓋文件時創建備份</translation>
     </message>
     <message>
         <source>Game Progress - Show Untested</source>
-        <translation>游戏进度 - 显示未测试项</translation>
+        <translation>遊戲進度 - 顯示未測試選項</translation>
     </message>
     <message>
         <source>NTSC-J</source>
@@ -1409,7 +1410,7 @@ Var And Scrolling Synced To Left Table</source>
     </message>
     <message>
         <source>Edit Places</source>
-        <translation>存档文件夹</translation>
+        <translation>存檔文件夾</translation>
     </message>
     <message>
         <source>PAL-DE</source>
@@ -1425,105 +1426,105 @@ Var And Scrolling Synced To Left Table</source>
     </message>
     <message>
         <source>Field Location - Show Map/X/Y/T/D</source>
-        <translation>野外位置 - 显示地图/X/Y/T/D坐标值</translation>
+        <translation>場景位置 - 顯示地圖/X/Y/T/D坐標值</translation>
     </message>
     <message>
         <source>Light Theme</source>
-        <translation>浅色主题</translation>
+        <translation>淺色主題</translation>
     </message>
     <message>
         <source>Select A Directory To Save mcd/mcr saves</source>
-        <translation>选择保存mcd/mcr存档的目录</translation>
+        <translation>選擇保存mcd/mcr存檔的目錄</translation>
     </message>
     <message>
         <source>Options</source>
-        <translation>选项</translation>
+        <translation>選項</translation>
     </message>
     <message>
         <source>Close and save changes</source>
-        <translation>关闭并保存更改</translation>
+        <translation>關閉並保存更改</translation>
     </message>
     <message>
         <source>New Game Default Region </source>
-        <translation>新存档默认区域</translation>
+        <translation>新存檔默認區域</translation>
     </message>
     <message>
         <source>Raw Psx Files Only!</source>
-        <translation>仅限原始PSX文件！</translation>
+        <translation>僅限原始PSX文件！</translation>
     </message>
     <message>
         <source>Show Experimental TestData Tab</source>
-        <translation>显示实验性测试数据标签页</translation>
+        <translation>顯示實驗性測試數據標簽頁</translation>
     </message>
     <message>
         <source>Fusion is the recommended theme&#xa0;
 &#xa0;Other themes may contain graphical issues.</source>
-        <translation type="vanished">Fusion是推荐主题
-其他主题可能存在图形问题。</translation>
+        <translation type="vanished">Fusion是推薦主題
+其他主題可能存在圖形問題。</translation>
     </message>
     <message>
         <source>Edit the Places show in sidebar on file dialogs</source>
-        <translation>编辑文件对话框侧边栏中显示的地点</translation>
+        <translation>編輯文件對話框側邊欄中顯示的地點</translation>
     </message>
     <message>
         <source>CharEditor - Advanced Mode</source>
-        <translation>角色编辑器 - 高级模式</translation>
+        <translation>角色編輯器 - 高級模式</translation>
     </message>
     <message>
         <source>Reset values to stored settings</source>
-        <translation>将值重置为已存储的设置</translation>
+        <translation>將值重置為已存儲的設置</translation>
     </message>
     <message>
         <source>Path For Emulator Memory Cards  </source>
-        <translation>模拟器记忆卡路径</translation>
+        <translation>模擬器記憶卡的文件夾路徑</translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The Native Dialog is unable to provide filename suggestions&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;原生对话框无法提供文件名建议&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;原生對話框無法提供文件名建議&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>System Theme</source>
-        <translation>系统主题</translation>
+        <translation>系統主題</translation>
     </message>
     <message>
         <source>Use Native File Dialogs</source>
-        <translation>使用系统默认位置</translation>
+        <translation>使用系統默認位置</translation>
     </message>
     <message>
         <source>Options - Always Show Controller Mapping </source>
-        <translation>选项 - 始终显示控制器映射 </translation>
+        <translation>選項 - 始終顯示控製器映射 </translation>
     </message>
     <message>
         <source>Editing</source>
-        <translation>编辑</translation>
+        <translation>編輯</translation>
     </message>
     <message>
         <source>Application Language</source>
-        <translation>应用程序语言</translation>
+        <translation>應用程序語言</translation>
     </message>
     <message>
         <source>Select A Location To Save Character Stat Files</source>
-        <translation>选择保存角色状态文件的位置</translation>
+        <translation>選擇保存角色數據文件的位置</translation>
     </message>
     <message>
         <source>Application Color Scheme</source>
-        <translation>应用程序配色方案</translation>
+        <translation>應用程序配色方案</translation>
     </message>
     <message>
         <source>Reset values to defaults</source>
-        <translation>将值重置为默认值</translation>
+        <translation>將值重置為默認值</translation>
     </message>
     <message>
         <source>Path For Character Stat Files And Backups</source>
-        <translation>角色状态文件和备份路径</translation>
+        <translation>角色數據和備份文件夾路徑</translation>
     </message>
     <message>
         <source>Dark Theme</source>
-        <translation>深色主题</translation>
+        <translation>深色主題</translation>
     </message>
     <message>
         <source>Close and forget changes</source>
-        <translation>关闭并放弃更改</translation>
+        <translation>關閉並放棄更改</translation>
     </message>
     <message>
         <source>General</source>
@@ -1531,31 +1532,32 @@ Var And Scrolling Synced To Left Table</source>
     </message>
     <message>
         <source>Select A Directory To Save FF7 PC Saves</source>
-        <translation>选择保存FF7 PC存档的目录</translation>
+        <translation>選擇保存FF7 PC存檔的目錄</translation>
     </message>
     <message>
         <source>Select A Directory To Load FF7 PC Saves From</source>
-        <translation>选择加载FF7 PC存档的目录</translation>
+        <translation>選擇加載FF7 PC存檔的目錄</translation>
     </message>
     <message>
         <source>Application Style</source>
-        <translation>应用程序样式</translation>
+        <translation>應用程序樣式</translation>
     </message>
     <message>
         <source>Show Placeholders In Materia and Item Selection</source>
-        <translation>在魔晶石和物品选择中显示占位符</translation>
+        <translation>在魔晶石和道具選擇中顯示占位符</translation>
     </message>
     <message>
         <source>Fusion is the recommended theme 
  Other themes may contain graphical issues.</source>
-        <translation type="unfinished"></translation>
+        <translation>推薦使用 Fusion 主題。
+其他主題可能存在圖形問題。</translation>
     </message>
 </context>
 <context>
     <name>PartyTab</name>
     <message>
         <source>Black Chocobo</source>
-        <translation>黑色陆行鸟</translation>
+        <translation>黑色陸行鳥</translation>
     </message>
     <message>
         <source>-Empty-</source>
@@ -1563,78 +1565,78 @@ Var And Scrolling Synced To Left Table</source>
     </message>
     <message>
         <source>Click on a Char To Edit  ===&gt;</source>
-        <translation>点击角色进行编辑&#xa0; ===&gt;</translation>
+        <translation>點擊角色進行編輯&#xa0; ===&gt;</translation>
     </message>
     <message>
         <source>Do You Want To Also Replace %1&apos;s Equipment and Materia?</source>
-        <translation>您是否也要替换 %1 的装备和魔晶石？</translation>
+        <translation>您是否也要替換 %1 的裝備和魔晶石？</translation>
     </message>
     <message>
         <source>Party Members</source>
-        <translation>队伍成员</translation>
+        <translation>隊伍成員</translation>
     </message>
     <message>
         <source>Selected Character Max Stats/Weapons/Materia</source>
-        <translation>所选角色最大属性/武器/魔晶石</translation>
+        <translation>選擇的角色 [屬性/裝備/魔晶石] 最大化</translation>
     </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
         <source>Close</source>
-        <translation>关闭</translation>
+        <translation>關閉</translation>
     </message>
     <message>
         <source>Add a place</source>
-        <translation>添加地点</translation>
+        <translation>添加地點</translation>
     </message>
     <message>
         <source>Adjust the play time?</source>
-        <translation>调整游戏时间吗？</translation>
+        <translation>調整遊戲時間嗎？</translation>
     </message>
     <message>
         <source>Edit Places</source>
-        <translation>存档文件夹</translation>
+        <translation>存檔文件夾</translation>
     </message>
     <message>
         <source>Failed To Save File</source>
-        <translation>保存文件失败</translation>
+        <translation>保存文件失敗</translation>
     </message>
     <message>
         <source>Places</source>
-        <translation>地点</translation>
+        <translation>地點</translation>
     </message>
     <message>
         <source>Remove selected place</source>
-        <translation>移除选定地点</translation>
+        <translation>移除選定地點</translation>
     </message>
     <message>
         <source>Close and save changes</source>
-        <translation>关闭并保存更改</translation>
+        <translation>關閉並保存更改</translation>
     </message>
     <message>
         <source>Restore default places</source>
-        <translation>恢复默认地点</translation>
+        <translation>恢復默認地點</translation>
     </message>
     <message>
         <source>PAL -&gt; NTSC Conversion</source>
-        <translation>PAL -&gt; NTSC 转换</translation>
+        <translation>PAL -&gt; NTSC 轉換</translation>
     </message>
     <message>
         <source>Reset values to stored settings</source>
-        <translation>重置为已存储设置</translation>
+        <translation>重置為已存儲設置</translation>
     </message>
     <message>
         <source>Select a path to add to places</source>
-        <translation>选择要添加到地点的路径</translation>
+        <translation>選擇要添加到地點的路徑</translation>
     </message>
     <message>
         <source>NTSC -&gt; PAL Conversion</source>
-        <translation>NTSC -&gt; PAL 转换</translation>
+        <translation>NTSC -&gt; PAL 轉換</translation>
     </message>
     <message>
         <source>Achievement Editor</source>
-        <translation>成就编辑器</translation>
+        <translation>成就編輯器</translation>
     </message>
     <message>
         <source>Save Changes</source>
@@ -1642,18 +1644,18 @@ Var And Scrolling Synced To Left Table</source>
     </message>
     <message>
         <source>Close and forget changes</source>
-        <translation>关闭并放弃更改</translation>
+        <translation>關閉並放棄更改</translation>
     </message>
     <message>
         <source>Old region was %1hz
 New region is %2hz</source>
-        <translation>旧区域为 %1 赫兹
-新区域为 %2 赫兹</translation>
+        <translation>舊區域為 %1 赫茲
+新區域為 %2 赫茲</translation>
     </message>
     <message>
         <source>Failed To Write File
 File:%1</source>
-        <translation>写入文件失败
+        <translation>寫入文件失敗
 文件：%1</translation>
     </message>
 </context>
@@ -1661,48 +1663,48 @@ File:%1</source>
     <name>UndoStack</name>
     <message>
         <source>Delete %1 chars</source>
-        <translation>删除 %1 个字符</translation>
+        <translation>刪除 %1 個字符</translation>
     </message>
     <message>
         <source>Inserting %1 bytes</source>
-        <translation>插入 %1 字节</translation>
+        <translation>插入 %1 字節</translation>
     </message>
     <message>
         <source>Overwrite %1 chars</source>
-        <translation>覆盖 %1 个字符</translation>
+        <translation>覆蓋 %1 個字符</translation>
     </message>
 </context>
 <context>
     <name>errbox</name>
     <message>
         <source>ERROR</source>
-        <translation>错误</translation>
+        <translation>錯誤</translation>
     </message>
     <message>
         <source>&#xa0; &#xa0; &#xa0; End Of Linked Blocks</source>
-        <translation type="vanished">&#xa0; &#xa0; &#xa0; 链接块末尾</translation>
+        <translation type="vanished">&#xa0; &#xa0; &#xa0; 鏈接塊末尾</translation>
     </message>
     <message numerus="yes">
         <source>
 &#xa0;Game Uses %n Save Block(s)</source>
         <translation type="vanished">
             <numerusform>
-&#xa0;游戏使用 %n 个存档块</numerusform>
+&#xa0;遊戲使用 %n 個存檔塊</numerusform>
         </translation>
     </message>
     <message>
         <source>
    Next Data Chunk @ Slot:%1</source>
         <translation>
-&#xa0; &#xa0;下一数据块 @ 插槽：%1</translation>
+&#xa0; &#xa0;下一數據塊 @ 插槽：%1</translation>
     </message>
     <message>
         <source>       Mid-Linked Block</source>
-        <translation>&#xa0; &#xa0; &#xa0; &#xa0;中间链接块</translation>
+        <translation>&#xa0; &#xa0; &#xa0; &#xa0;中間鏈接塊</translation>
     </message>
     <message>
         <source>    Mid-Linked Block (Deleted)</source>
-        <translation>&#xa0; &#xa0; 中间链接块（已删除）</translation>
+        <translation>&#xa0; &#xa0; 中間鏈接塊（已刪除）</translation>
     </message>
     <message>
         <source>Slot:%1
@@ -1712,33 +1714,33 @@ File:%1</source>
     </message>
     <message>
         <source>View Anyway</source>
-        <translation>无论如何都查看</translation>
+        <translation>無論如何都查看</translation>
     </message>
     <message>
         <source>Non Final Fantasy VII Slot</source>
-        <translation>非最终幻想VII插槽</translation>
+        <translation>非最終幻想VII插槽</translation>
     </message>
     <message>
         <source>&#xa0; &#xa0; &#xa0; End Of Linked Blocks (Deleted)</source>
-        <translation type="vanished">&#xa0; &#xa0; &#xa0; 链接块末尾（已删除）</translation>
+        <translation type="vanished">&#xa0; &#xa0; &#xa0; 鏈接塊末尾（已刪除）</translation>
     </message>
     <message>
         <source>E&amp;xport Slot</source>
-        <translation>导&amp;出插槽</translation>
+        <translation>導&amp;出插槽</translation>
     </message>
     <message>
         <source>      End Of Linked Blocks</source>
-        <translation type="unfinished"></translation>
+        <translation>      鏈接塊末尾（已刪除）</translation>
     </message>
     <message>
         <source>      End Of Linked Blocks (Deleted)</source>
-        <translation type="unfinished"></translation>
+        <translation>      鏈接塊末尾（已刪除）</translation>
     </message>
     <message numerus="yes">
         <source>
- 游戏使用 %n 个存档块(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
+ Game Uses %n Save Block(s)</source>
+        <translation>
+            <numerusform>遊戲使用%n個存檔塊</numerusform>
         </translation>
     </message>
 </context>


### PR DESCRIPTION
Renamed blackchocobo_zh.ts to blackchocobo_zh_CN.ts and updated its language code and translations for Simplified Chinese. Added a new Traditional Chinese translation file, blackchocobo_zh_TW.ts. Updated CMakeLists.txt to reference both zh_CN and zh_TW translation files and adjusted related install paths and language codes accordingly.