### PR TITLE
Complete Chinese translation synchronized with FF7 FFSky ver.3

### DIFF
--- a/translations/CMakeLists.txt
+++ b/translations/CMakeLists.txt
@@ -16,6 +16,8 @@ set ( blackchocobo_TRS
     blackchocobo_ja.ts
     blackchocobo_pl.ts
     blackchocobo_re.ts
+    blackchocobo_zh_CN.ts
+    blackchocobo_zh_TW.ts
 )
 
 if(WIN32 OR APPLE)
@@ -32,6 +34,8 @@ if(WIN32 OR APPLE)
         ${ff7tk_I18N_PATH}/ff7tk_ja.qm
         ${ff7tk_I18N_PATH}/ff7tk_pl.qm
         ${ff7tk_I18N_PATH}/ff7tk_re.qm
+        ${ff7tk_I18N_PATH}/ff7tk_zh_CN.qm
+        ${ff7tk_I18N_PATH}/ff7tk_zh_TW.qm
     )
 endif()
 

--- a/translations/blackchocobo_zh_CN.ts
+++ b/translations/blackchocobo_zh_CN.ts
@@ -1,0 +1,1706 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_CN">
+<context>
+    <name>About</name>
+    <message>
+        <source>About Black Chocobo</source>
+        <translation>关于 Black Chocobo 存档修改器</translation>
+    </message>
+    <message>
+        <source>Black Chocobo </source>
+        <translation>Black Chocobo 存档修改器</translation>
+    </message>
+    <message>
+        <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Ubuntu&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a href=&quot;http://sourceforge.net/p/blackchocobo/donate&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#508ed8;&quot;&gt;Support this Project&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Ubuntu&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a href=&quot;http://sourceforge.net/p/blackchocobo/donate&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#508ed8;&quot;&gt;支持这个项目&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <source>Translators</source>
+        <translation>翻译人员</translation>
+    </message>
+    <message>
+        <source>Spanish Translation:</source>
+        <translation>西班牙语翻译:</translation>
+    </message>
+    <message>
+        <source>French Translation:</source>
+        <translation>法语翻译:</translation>
+    </message>
+    <message>
+        <source>Japanese Translation:</source>
+        <translation>日语翻译:</translation>
+    </message>
+    <message>
+        <source>German Translation:</source>
+        <translation>德语翻译:</translation>
+    </message>
+    <message>
+        <source>Version: %1</source>
+        <translation>版本：%1</translation>
+    </message>
+    <message>
+        <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Ubuntu&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a href=&quot;http://www.gnu.org/licenses/gpl.html&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#508ed8;&quot;&gt;License: GNU GPL Version 3&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Ubuntu&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a href=&quot;http://www.gnu.org/licenses/gpl.html&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#508ed8;&quot;&gt;许可证: GNU GPL Version 3&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <source>&amp;Close</source>
+        <translation>关闭</translation>
+    </message>
+    <message>
+        <source>ff7tk: %1</source>
+        <translation>ff7tk: %1</translation>
+    </message>
+    <message>
+        <source>Qt: %1</source>
+        <translation>Qt: %1</translation>
+    </message>
+    <message>
+        <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Ubuntu&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a href=&quot;https://github.com/sithlord48/blackchocobo&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#508ed8;&quot;&gt;Project Page&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Ubuntu&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a href=&quot;https://github.com/sithlord48/blackchocobo&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#508ed8;&quot;&gt;项目页面&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <source>Polish Translation:</source>
+        <translation>波兰语翻译:</translation>
+    </message>
+    <message>
+        <source>Additonal Credits</source>
+        <translation>致谢</translation>
+    </message>
+    <message>
+        <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Ubuntu&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a href=&quot;https://github.com/sithlord48/blackchocobo/graphs/contributors&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#508ed8;&quot;&gt;Code Contributors&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Ubuntu&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a href=&quot;https://github.com/sithlord48/blackchocobo/graphs/contributors&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#508ed8;&quot;&gt;代码贡献者&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <source>Icons used In this Program</source>
+        <translation>此程序使用的图标</translation>
+    </message>
+</context>
+<context>
+    <name>BlackChocobo</name>
+    <message>
+        <source>Black Chocobo</source>
+        <translation>Black Chocobo 存档修改器</translation>
+    </message>
+    <message>
+        <source>AP</source>
+        <translation>AP</translation>
+    </message>
+    <message>
+        <source>Party&apos;s Materia Stock</source>
+        <translation>已拥有的魔石</translation>
+    </message>
+    <message>
+        <source>Materia</source>
+        <translation>魔石</translation>
+    </message>
+    <message>
+        <source>Master</source>
+        <translation>最高等级</translation>
+    </message>
+    <message>
+        <source>Materia Stolen By Yuffie</source>
+        <translation>被尤菲偷走的魔石</translation>
+    </message>
+    <message>
+        <source>Ctrl+O</source>
+        <translation>Ctrl+O</translation>
+    </message>
+    <message>
+        <source>Time Played</source>
+        <translation>累计游戏时间</translation>
+    </message>
+    <message>
+        <source>Sec</source>
+        <translation>秒</translation>
+    </message>
+    <message>
+        <source>Love Points</source>
+        <translation>好感度</translation>
+    </message>
+    <message>
+        <source>Selected Materia Skills and Stat Info</source>
+        <translation>所选魔石的技能与状态信息</translation>
+    </message>
+    <message>
+        <source>Bombing Mission Progress</source>
+        <translation>爆破任务进程</translation>
+    </message>
+    <message>
+        <source>Bombing Mission</source>
+        <translation>爆破任务</translation>
+    </message>
+    <message>
+        <source>Cloud&apos;s Flashback</source>
+        <translation>克劳德的回忆</translation>
+    </message>
+    <message>
+        <source>The Date Scene</source>
+        <translation>约会场景</translation>
+    </message>
+    <message>
+        <source>Replay Mission</source>
+        <translation>重玩任务</translation>
+    </message>
+    <message>
+        <source>         INFO ON CURRENTLY SELECTED REPLAY MISSION</source>
+        <translation>         当前选择重玩的任务信息</translation>
+    </message>
+    <message>
+        <source>&amp;File</source>
+        <translation>文件</translation>
+    </message>
+    <message>
+        <source>&amp;Quit</source>
+        <translation>退出</translation>
+    </message>
+    <message>
+        <source>Open Final Fantasy 7 Save</source>
+        <translation>打开一个FF7存档文件</translation>
+    </message>
+    <message>
+        <source>Cannot read file %1:
+%2.</source>
+        <translation>无法读取文件 %1:
+%2.</translation>
+    </message>
+    <message>
+        <source>Hour</source>
+        <translation>小时</translation>
+    </message>
+    <message>
+        <source>Min</source>
+        <translation>分钟</translation>
+    </message>
+    <message>
+        <source>Coaster Shooter High Scores</source>
+        <translation>过山车射击最高分</translation>
+    </message>
+    <message>
+        <source>1st</source>
+        <translation>1st</translation>
+    </message>
+    <message>
+        <source>2nd</source>
+        <translation>2nd</translation>
+    </message>
+    <message>
+        <source>3rd</source>
+        <translation>3rd</translation>
+    </message>
+    <message>
+        <source>Test Data</source>
+        <translation>测试数据</translation>
+    </message>
+    <message>
+        <source>Tutorials Seen</source>
+        <translation>已经看过教程</translation>
+    </message>
+    <message>
+        <source>Controling the Sub</source>
+        <translation>如何控制潜水艇</translation>
+    </message>
+    <message>
+        <source>Saving on the World Map</source>
+        <translation>在大地图上存档</translation>
+    </message>
+    <message>
+        <source>Battle Love Points</source>
+        <translation>战斗好感度</translation>
+    </message>
+    <message>
+        <source>Ultimate Weapons Hp</source>
+        <translation>究极神兵 剩余HP</translation>
+    </message>
+    <message>
+        <source>Countdown Timer</source>
+        <translation>倒数计时器</translation>
+    </message>
+    <message>
+        <source>&amp;Edit</source>
+        <translation>编辑</translation>
+    </message>
+    <message>
+        <source>Select FF7 Character Stat File</source>
+        <translation>选择FF7角色状态文件</translation>
+    </message>
+    <message>
+        <source>%1:
+%2 is Not a FF7 Character Stat File.</source>
+        <translation>%1:
+%2 不是FF7角色状态文件</translation>
+    </message>
+    <message>
+        <source>Save FF7 Character File</source>
+        <translation>保存FF7角色状态文件</translation>
+    </message>
+    <message>
+        <source>FF7 Character Stat File(*.char)</source>
+        <translation>FF7角色状态文件 (*.char)</translation>
+    </message>
+    <message>
+        <source>===Empty Slot===</source>
+        <translation>===空===</translation>
+    </message>
+    <message>
+        <source>Highwind</source>
+        <translation>疾风号</translation>
+    </message>
+    <message>
+        <source>&amp;Open</source>
+        <translation>打开</translation>
+    </message>
+    <message>
+        <source>&amp;Save</source>
+        <translation>保存</translation>
+    </message>
+    <message>
+        <source>Misc</source>
+        <translation>杂项</translation>
+    </message>
+    <message>
+        <source>Party leader</source>
+        <translation>正在操控的主角</translation>
+    </message>
+    <message>
+        <source>angle</source>
+        <translation>面朝方向</translation>
+    </message>
+    <message>
+        <source>id</source>
+        <translation>id</translation>
+    </message>
+    <message>
+        <source>Tiny Bronco / Chocobo</source>
+        <translation>小野马 / 陆行鸟</translation>
+    </message>
+    <message>
+        <source>Buggy / Highwind</source>
+        <translation>越野车 / 疾风号</translation>
+    </message>
+    <message>
+        <source>Sub</source>
+        <translation>潜艇</translation>
+    </message>
+    <message>
+        <source>sliders show </source>
+        <translation>显示滑动条</translation>
+    </message>
+    <message>
+        <source>Party Leader</source>
+        <translation>正在操控的主角</translation>
+    </message>
+    <message>
+        <source>TinyBronco/Chocobo</source>
+        <translation>小野马/陆行鸟</translation>
+    </message>
+    <message>
+        <source>Buggy/Highwind</source>
+        <translation>越野车/疾风号</translation>
+    </message>
+    <message>
+        <source>Wild Chocobo</source>
+        <translation>野生陆行鸟</translation>
+    </message>
+    <message>
+        <source>Diamond / Ultimate / Ruby Weapon</source>
+        <translation>钻石 / 究极 / 红宝石 神兵</translation>
+    </message>
+    <message>
+        <source>The Church In The Slums</source>
+        <translation>贫民窟教堂</translation>
+    </message>
+    <message>
+        <source>Aeris Death</source>
+        <translation>爱丽丝之死</translation>
+    </message>
+    <message>
+        <source>Worldmap Location</source>
+        <translation>大地图位置</translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation>无</translation>
+    </message>
+    <message>
+        <source>Buggy</source>
+        <translation>越野车</translation>
+    </message>
+    <message>
+        <source>Replay the bombing mission from right after you get off the train.</source>
+        <translation>重玩爆破任务 (从跳下列车开始)</translation>
+    </message>
+    <message>
+        <source>Replay the death of Aeris.This option Will remove Aeris from your PHS</source>
+        <translation>重玩爱丽丝之死剧情。此选项会从PHS中移除爱丽丝。</translation>
+    </message>
+    <message>
+        <source>Meeting Aeris</source>
+        <translation>遇见爱丽丝</translation>
+    </message>
+    <message>
+        <source>Diamond / Ultimate / Ruby  Weapon</source>
+        <translation>钻石 / 究极 / 红宝石 神兵</translation>
+    </message>
+    <message>
+        <source>Remove ALL Materia </source>
+        <translation>移除所有魔石</translation>
+    </message>
+    <message>
+        <source>Clear All Stolen Materia</source>
+        <translation>清空所有被偷走的魔石</translation>
+    </message>
+    <message>
+        <source>-None-</source>
+        <translation>-无-</translation>
+    </message>
+    <message>
+        <source>Unknown Var:</source>
+        <translation>Unknown Var:</translation>
+    </message>
+    <message>
+        <source>#</source>
+        <translation>#</translation>
+    </message>
+    <message>
+        <source>Hex</source>
+        <translation>Hex</translation>
+    </message>
+    <message>
+        <source>Dec</source>
+        <translation>Dec</translation>
+    </message>
+    <message>
+        <source>Bin</source>
+        <translation>Bin</translation>
+    </message>
+    <message>
+        <source>Compare To Slot</source>
+        <translation>存档进度对比</translation>
+    </message>
+    <message>
+        <source>------Right Table------&gt;
+Select A Slot To Compare
+Table is Read Only
+Var And Scrolling Synced To Left Table</source>
+        <translation>------右表格------&gt;
+选择一个存档进度进行比较
+表格是只读的
+变量和滚动同步到左表格</translation>
+    </message>
+    <message>
+        <source>Y: </source>
+        <translation>Y: </translation>
+    </message>
+    <message>
+        <source>Global Progress</source>
+        <translation>整体进程</translation>
+    </message>
+    <message>
+        <source>Main Progression</source>
+        <translation>PPV (剧情进度值)</translation>
+    </message>
+    <message>
+        <source>Elevator Door Open</source>
+        <translation>电梯门打开</translation>
+    </message>
+    <message>
+        <source>1st Door Open</source>
+        <translation>第一个门打开</translation>
+    </message>
+    <message>
+        <source>2nd Door Opened</source>
+        <translation>第二个门打开了</translation>
+    </message>
+    <message>
+        <source>The Bomb Was Set</source>
+        <translation>炸弹已安装</translation>
+    </message>
+    <message>
+        <source>Event Progress</source>
+        <translation>事件进程</translation>
+    </message>
+    <message>
+        <source>Escape From Reactor </source>
+        <translation>逃离魔晄炉</translation>
+    </message>
+    <message>
+        <source>Post Pan MD8_2</source>
+        <translation>在 MD8_2 放置了Pan</translation>
+    </message>
+    <message>
+        <source>Midgar Train Flags</source>
+        <translation>米德加列车标记</translation>
+    </message>
+    <message>
+        <source>Talked to Wedge Twice</source>
+        <translation>与威吉交谈了两次</translation>
+    </message>
+    <message>
+        <source> Played Video on Train?</source>
+        <translation>在列车上播放了视频？</translation>
+    </message>
+    <message>
+        <source>Unknowns / Unused</source>
+        <translation>未知 / 未使用</translation>
+    </message>
+    <message>
+        <source>Sector 7 Trainstation</source>
+        <translation>7号街车站</translation>
+    </message>
+    <message>
+        <source>Talked To Trainman 3 times</source>
+        <translation>与列车员交谈了三次</translation>
+    </message>
+    <message>
+        <source>Pair At Station agree</source>
+        <translation>伙伴在车站同意</translation>
+    </message>
+    <message>
+        <source>Set To Reactor 5 Mode</source>
+        <translation>设置到5号魔晄炉模式</translation>
+    </message>
+    <message>
+        <source>Sector 7 Pillar</source>
+        <translation>7号街支柱</translation>
+    </message>
+    <message>
+        <source>Can Show Pillar Pan Video</source>
+        <translation>可以显示 Pillar Pan 视频</translation>
+    </message>
+    <message>
+        <source>Barret called us</source>
+        <translation>巴雷特呼叫了大家</translation>
+    </message>
+    <message>
+        <source>Post Pillar Pan Video</source>
+        <translation>收集 Pillar Pan 视频</translation>
+    </message>
+    <message>
+        <source>Talked To soldier two times</source>
+        <translation>与神罗兵交谈了两次</translation>
+    </message>
+    <message>
+        <source>Elevator On 2nd Floor</source>
+        <translation>电梯在第二层</translation>
+    </message>
+    <message>
+        <source>Post Pan NMKIN_5</source>
+        <translation>在 NMKIN_5 放置了Pan</translation>
+    </message>
+    <message>
+        <source>Post Electrical Effect MD8_3</source>
+        <translation>在场景 MD8_3 放置电流特效</translation>
+    </message>
+    <message>
+        <source>&lt;------Left Table------
+Select Unknown Var To View
+Table Entries are Editable</source>
+        <translation>&lt;------Left Table------
+Select Unknown Var To View
+Table Entries are Editable</translation>
+    </message>
+    <message>
+        <source>Talked to Biggs</source>
+        <translation>与毕格斯交谈过</translation>
+    </message>
+    <message>
+        <source>Sector 7 - Slums Progress</source>
+        <translation>7号街 - 贫民窟 进程</translation>
+    </message>
+    <message>
+        <source>Initial Settings</source>
+        <translation>初始设置</translation>
+    </message>
+    <message>
+        <source>Destroy the Sector 5 Reactor </source>
+        <translation>炸毁5号魔晄炉</translation>
+    </message>
+    <message>
+        <source>The Plate is Falling</source>
+        <translation>圆盘正在坠落</translation>
+    </message>
+    <message>
+        <source>Unsaved Changes</source>
+        <translation>未保存的更改</translation>
+    </message>
+    <message>
+        <source>Save Changes to the File:
+%1</source>
+        <translation>将更改保存到:
+%1</translation>
+    </message>
+    <message>
+        <source>Save Error</source>
+        <translation>保存出错</translation>
+    </message>
+    <message>
+        <source>Visible On World Map</source>
+        <translation>在大地图上可见</translation>
+    </message>
+    <message>
+        <source>Tiny bronco</source>
+        <translation>小野马</translation>
+    </message>
+    <message>
+        <source>Unknown Id in Buggy/Highwind Location</source>
+        <translation>未知的 越野车/疾风号 位置</translation>
+    </message>
+    <message>
+        <source>Wild chocobo</source>
+        <translation>野生陆行鸟</translation>
+    </message>
+    <message>
+        <source>Yellow chocobo</source>
+        <translation>陆行鸟 (黄)</translation>
+    </message>
+    <message>
+        <source>Green chocobo</source>
+        <translation>山陆行鸟 (绿)</translation>
+    </message>
+    <message>
+        <source>Blue chocobo</source>
+        <translation>川陆行鸟 (蓝)</translation>
+    </message>
+    <message>
+        <source>Black chocobo</source>
+        <translation>山川陆行鸟 (黑)</translation>
+    </message>
+    <message>
+        <source>Gold chocobo</source>
+        <translation>海陆行鸟 (金)</translation>
+    </message>
+    <message>
+        <source>Load Failed</source>
+        <translation>加载失败</translation>
+    </message>
+    <message>
+        <source>Failed to Load File</source>
+        <translation>文件加载失败</translation>
+    </message>
+    <message>
+        <source>Failed to save file
+%1</source>
+        <translation>文件保存失败
+%1</translation>
+    </message>
+    <message>
+        <source>Can Fight Mystery Ninja in Forests</source>
+        <translation>能够在森林中对战神秘忍者</translation>
+    </message>
+    <message>
+        <source>Add Each Materia to Stock (end of list)</source>
+        <translation>获得所有种类的魔石（从库存最下列往上数）</translation>
+    </message>
+    <message>
+        <source>Beginner Course</source>
+        <translation>初级赛道</translation>
+    </message>
+    <message>
+        <source>Time:</source>
+        <translation>时间:</translation>
+    </message>
+    <message>
+        <source>:</source>
+        <translation>:</translation>
+    </message>
+    <message>
+        <source>.</source>
+        <translation>.</translation>
+    </message>
+    <message>
+        <source>Score:</source>
+        <translation>分数：</translation>
+    </message>
+    <message>
+        <source>Points</source>
+        <translation>分</translation>
+    </message>
+    <message>
+        <source>Expert Course</source>
+        <translation>高级赛道</translation>
+    </message>
+    <message>
+        <source>Crazy Course</source>
+        <translation>疯狂赛道</translation>
+    </message>
+    <message>
+        <source>Beat Ruby Weapon</source>
+        <translation>击败红宝石神兵</translation>
+    </message>
+    <message>
+        <source>Beat Emerald Weapon</source>
+        <translation>击败绿宝石神兵</translation>
+    </message>
+    <message>
+        <source>Battle Points</source>
+        <translation>战斗点数</translation>
+    </message>
+    <message>
+        <source>Hex Editor</source>
+        <translation>Hex 编辑器</translation>
+    </message>
+    <message>
+        <source>Show:</source>
+        <translation>显示:</translation>
+    </message>
+    <message>
+        <source>Unknown Vars</source>
+        <translation>Unknown Vars</translation>
+    </message>
+    <message>
+        <source>Replay the Date Scene, Your Location will be set To The Ropeway Station Talk to man by the Tram to start event. If Your Looking for a special Date be sure to set your love points too.</source>
+        <translation>重玩约会场景，你的位置将被设置到观光缆车站。在进行约会之前，别忘了修改你想要约会的角色的好感度。</translation>
+    </message>
+    <message>
+        <source>PSX Save Data</source>
+        <translation>PSX 存档数据</translation>
+    </message>
+    <message>
+        <source>Game Options</source>
+        <translation>游戏内设置</translation>
+    </message>
+    <message>
+        <source>Character Export Successful</source>
+        <translation>角色状态文件导入成功</translation>
+    </message>
+    <message>
+        <source>Character Export Failed</source>
+        <translation>角色状态文件导入失败</translation>
+    </message>
+    <message>
+        <source>Export Successful</source>
+        <translation>导出成功</translation>
+    </message>
+    <message>
+        <source>Export Failed</source>
+        <translation>导出失败</translation>
+    </message>
+    <message>
+        <source>Fort Condor</source>
+        <translation>秃鹫要塞</translation>
+    </message>
+    <message>
+        <source>Funds </source>
+        <translation>资金</translation>
+    </message>
+    <message>
+        <source>Record </source>
+        <translation>记录</translation>
+    </message>
+    <message>
+        <source>/</source>
+        <translation>/</translation>
+    </message>
+    <message>
+        <source>Bombing Mission Start Flag</source>
+        <translation>爆破任务开始标记</translation>
+    </message>
+    <message>
+        <source>Builtin Data</source>
+        <translation>内部数据</translation>
+    </message>
+    <message>
+        <source>New Game Created - Using: %1</source>
+        <translation>新游戏初始存档已创建 - 正在使用: %1 (清空所有角色练度、道具、魔石，重新开始新游戏)</translation>
+    </message>
+    <message>
+        <source>New Game Plus Created - Using: %1</source>
+        <translation>N周目继承存档已创建 - 正在使用: %1 (角色练度、道具、魔石继承到新游戏初始进度)</translation>
+    </message>
+    <message>
+        <source>Have Seen Pandora&apos;s Box</source>
+        <translation>已看过潘多拉魔盒技能</translation>
+    </message>
+    <message>
+        <source>Imported Slot:%2 from %1 -&gt; Slot:%3</source>
+        <translation>将 %1 中的进度:%2 导入到进度:%3</translation>
+    </message>
+    <message>
+        <source>&amp;Copy Current Slot</source>
+        <translation>复制当前的进度</translation>
+    </message>
+    <message>
+        <source>&amp;Paste Slot</source>
+        <translation>粘贴已复制的进度</translation>
+    </message>
+    <message>
+        <source>Clea&amp;r Slot</source>
+        <translation>删除当前进度</translation>
+    </message>
+    <message>
+        <source>&amp;New Game</source>
+        <translation>创建新游戏初始存档</translation>
+    </message>
+    <message>
+        <source>E&amp;xport Current Character</source>
+        <translation>导出当前角色状态</translation>
+    </message>
+    <message>
+        <source>I&amp;mport Current Character</source>
+        <translation>导入角色状态文件</translation>
+    </message>
+    <message>
+        <source>DonProgress</source>
+        <translation>DonProgress</translation>
+    </message>
+    <message>
+        <source>&amp;Import To Current Slot</source>
+        <translation>选择其它存档的单个进度 替换当前进度</translation>
+    </message>
+    <message>
+        <source>Party</source>
+        <translation>队伍</translation>
+    </message>
+    <message>
+        <source>Items</source>
+        <translation>道具</translation>
+    </message>
+    <message>
+        <source>Location</source>
+        <translation>主角所在位置</translation>
+    </message>
+    <message>
+        <source>Field Location</source>
+        <translation>场景位置</translation>
+    </message>
+    <message>
+        <source>Right click on map to easily set an item&apos;s
+location.</source>
+        <translation>右键单击地图，放置道具。</translation>
+    </message>
+    <message>
+        <source>Game Progress</source>
+        <translation>游戏进程</translation>
+    </message>
+    <message>
+        <source>Disc  #</source>
+        <translation>光盘  #</translation>
+    </message>
+    <message>
+        <source>Jessie Has Been Unstuck</source>
+        <translation>杰西已经摆脱困境</translation>
+    </message>
+    <message>
+        <source>Trigger Game Over (countdown reached 0)</source>
+        <translation>触发游戏结束 (倒计时到达 0)</translation>
+    </message>
+    <message>
+        <source>Talked to Jessie Before Looking At Map</source>
+        <translation>在观看地图前与杰西交谈过</translation>
+    </message>
+    <message>
+        <source>Avalanche had meeting after Bombing Mission</source>
+        <translation>雪崩在爆破任务后会合</translation>
+    </message>
+    <message>
+        <source>Avalanche Has Run To Hideout</source>
+        <translation>雪崩前往了藏身处</translation>
+    </message>
+    <message>
+        <source>ChurchProgress</source>
+        <translation>教堂进程</translation>
+    </message>
+    <message>
+        <source>Set Replay Mission below to set the game back to that mission. This will automatically set your save location and disc # as well as Quest Progression vars. DO NOT OVERWRITE YOUR CURRENT SAVE when using this feature; I cannot promise that you will be able to play from any replay until the end of the game, or that any given replay will work in your save. This feature is still under development.</source>
+        <translation>“重玩任务”是开发中的功能，不建议使用。</translation>
+    </message>
+    <message>
+        <source>Apply Selected Replay </source>
+        <translation>应用所选任务</translation>
+    </message>
+    <message>
+        <source>Other</source>
+        <translation>其它</translation>
+    </message>
+    <message>
+        <source>Unlocked Vincent</source>
+        <translation>文森特已入队</translation>
+    </message>
+    <message>
+        <source>Unlocked Yuffie </source>
+        <translation>尤菲已入队</translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Resets
+When you Pass thru Battle Square&apos;s Door Set Location To &amp;quot;Arena
+Lobby&amp;quot; so you can spend
+them&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;当你通过战斗过场的门，重新进入斗技场大厅之后，才可以使用修改过的战斗点数(BP)。(不确定是否有效)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <source>Number of Steps</source>
+        <translation>步数</translation>
+    </message>
+    <message>
+        <source>Cait Sith and Vincent should not be enabled if they are disabled in the Party tab.</source>
+        <translation>如果凯特西、文森特不在队伍中，请不要勾选他们的选项</translation>
+    </message>
+    <message>
+        <source>Snowboard Mini Game </source>
+        <translation>滑雪小游戏</translation>
+    </message>
+    <message>
+        <source>G-Bike High Score</source>
+        <translation>G-Bike 最高分</translation>
+    </message>
+    <message>
+        <source>Have Won the Submarine Game</source>
+        <translation>潜艇游戏已获胜</translation>
+    </message>
+    <message>
+        <source>Playstation Save Info</source>
+        <translation>PlayStation 存档信息</translation>
+    </message>
+    <message>
+        <source>PsxName:</source>
+        <translation>Psx名称:</translation>
+    </message>
+    <message>
+        <source>No Description Text</source>
+        <translation>无描述文本</translation>
+    </message>
+    <message>
+        <source>Save Point Location In North Crater</source>
+        <translation>记录点位置在大空洞</translation>
+    </message>
+    <message>
+        <source>Map Id: </source>
+        <translation>地图ID: </translation>
+    </message>
+    <message>
+        <source>X: </source>
+        <translation>X: </translation>
+    </message>
+    <message>
+        <source>Z:</source>
+        <translation>Z:</translation>
+    </message>
+    <message>
+        <source>He&amp;lp</source>
+        <translation>帮助</translation>
+    </message>
+    <message>
+        <source>&amp;View</source>
+        <translation>进度切换</translation>
+    </message>
+    <message>
+        <source>&amp;Settings</source>
+        <translation>修改器设置</translation>
+    </message>
+    <message>
+        <source>&amp;Slot Region</source>
+        <translation>更改进度的区域 (不同平台存档转换)</translation>
+    </message>
+    <message>
+        <source>Ctrl+Q</source>
+        <translation>Ctrl+Q</translation>
+    </message>
+    <message>
+        <source>Sa&amp;ve As</source>
+        <translation>另存为</translation>
+    </message>
+    <message>
+        <source>Ctrl+Shift+S</source>
+        <translation>Ctrl+Shift+S</translation>
+    </message>
+    <message>
+        <source>&amp;About</source>
+        <translation>关于</translation>
+    </message>
+    <message>
+        <source>&amp;Select Slot</source>
+        <translation>选择其它进度</translation>
+    </message>
+    <message>
+        <source>F4</source>
+        <translation>F4</translation>
+    </message>
+    <message>
+        <source>Ctrl+Shift+C</source>
+        <translation>Ctrl+Shift+C</translation>
+    </message>
+    <message>
+        <source>Ctrl+Shift+V</source>
+        <translation>Ctrl+Shift+V</translation>
+    </message>
+    <message>
+        <source>Ctrl+Shift+Del</source>
+        <translation>Ctrl+Shift+Del</translation>
+    </message>
+    <message>
+        <source>&amp;Previous Slot</source>
+        <translation>当前存档的上一个进度</translation>
+    </message>
+    <message>
+        <source>Alt+Left</source>
+        <translation>Alt+Left</translation>
+    </message>
+    <message>
+        <source>&amp;Next Slot</source>
+        <translation>当前存档的下一个进度</translation>
+    </message>
+    <message>
+        <source>Alt+Right</source>
+        <translation>Alt+Right</translation>
+    </message>
+    <message>
+        <source>&amp;Configure</source>
+        <translation>自定义</translation>
+    </message>
+    <message>
+        <source>Application Preferences</source>
+        <translation>修改器首选项</translation>
+    </message>
+    <message>
+        <source>F2</source>
+        <translation>F2</translation>
+    </message>
+    <message>
+        <source>&amp;Us English (NTSC-U)</source>
+        <translation>&amp;Us English (NTSC-U)</translation>
+    </message>
+    <message>
+        <source>Uk &amp;English (PAL)</source>
+        <translation>Uk &amp;English (PAL)</translation>
+    </message>
+    <message>
+        <source>&amp;German (PAL)</source>
+        <translation>&amp;German (PAL)</translation>
+    </message>
+    <message>
+        <source>&amp;Spanish (PAL)</source>
+        <translation>&amp;Spanish (PAL)</translation>
+    </message>
+    <message>
+        <source>Spanish (PAL)</source>
+        <translation>Spanish (PAL)</translation>
+    </message>
+    <message>
+        <source>&amp;Japanese (NTSC-J)</source>
+        <translation>&amp;Japanese (NTSC-J)</translation>
+    </message>
+    <message>
+        <source>Japanese (NTSC-J)</source>
+        <translation>Japanese (NTSC-J)</translation>
+    </message>
+    <message>
+        <source>&amp;International (NTSC-J)</source>
+        <translation>&amp;International (NTSC-J)</translation>
+    </message>
+    <message>
+        <source>International (NTSC-J)</source>
+        <translation>International (NTSC-J)</translation>
+    </message>
+    <message>
+        <source>Ctrl+Shift+N</source>
+        <translation>Ctrl+Shift+N</translation>
+    </message>
+    <message>
+        <source>Ctrl+Shift+=</source>
+        <translation>Ctrl+Shift+=</translation>
+    </message>
+    <message>
+        <source>Ctrl+E</source>
+        <translation>Ctrl+E</translation>
+    </message>
+    <message>
+        <source>Ctrl+Ins</source>
+        <translation>Ctrl+Ins</translation>
+    </message>
+    <message>
+        <source>&amp;Reload</source>
+        <translation>重新加载</translation>
+    </message>
+    <message>
+        <source>&amp;French (PAL)</source>
+        <translation>&amp;French (PAL)</translation>
+    </message>
+    <message>
+        <source>Create Cloud Save &amp;Folder</source>
+        <translation>创建云存档 以及文件夹</translation>
+    </message>
+    <message>
+        <source>F9</source>
+        <translation>F9</translation>
+    </message>
+    <message>
+        <source>Ctrl+Shift+Ins</source>
+        <translation>Ctrl+Shift+Ins</translation>
+    </message>
+    <message>
+        <source>&amp;Achievement Editor</source>
+        <translation>成就编辑</translation>
+    </message>
+    <message>
+        <source>F10</source>
+        <translation>F10</translation>
+    </message>
+    <message>
+        <source>Chocobo</source>
+        <translation>陆行鸟</translation>
+    </message>
+    <message>
+        <source>Slot</source>
+        <translation>进度</translation>
+    </message>
+    <message>
+        <source>Imported %1 -&gt; Slot:%2</source>
+        <translation>将 %1 导入到进度:%2</translation>
+    </message>
+    <message>
+        <source>Error Loading File %1</source>
+        <translation>加载文件失败 %1</translation>
+    </message>
+    <message>
+        <source>Select A File to Save As</source>
+        <translation>选择另存为哪个文件</translation>
+    </message>
+    <message>
+        <source>Select Achievement File</source>
+        <translation>选择成就记录文件 (achievement.dat)</translation>
+    </message>
+    <message>
+        <source>Dat File (*.dat)</source>
+        <translation>Dat 文件 (*.dat)</translation>
+    </message>
+    <message>
+        <source>Current Slot:%1</source>
+        <translation>当前进度:%1</translation>
+    </message>
+    <message>
+        <source>Exported Slot:%2 from %1 -&gt; %3</source>
+        <translation>将进度:%2 从 %1 导出到 %3</translation>
+    </message>
+    <message>
+        <source>
+ Mid-Linked Block </source>
+        <translation>
+ 中段存档位 </translation>
+    </message>
+    <message>
+        <source>
+ End Of Linked Data</source>
+        <translation>
+最后一个关联数据</translation>
+    </message>
+    <message>
+        <source>(Deleted)</source>
+        <translation>(已删除)</translation>
+    </message>
+    <message numerus="yes">
+        <source>Game Uses %n Save Block(s)</source>
+        <translation>
+            <numerusform>游戏使用 %n 存档位</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>
+  Next Data Chunk @ Slot:%1</source>
+        <translation>
+  下一个数据块 @ 进度:%1</translation>
+    </message>
+    <message>
+        <source>All Materia Added!</source>
+        <translation>已获得所有种类的魔石！</translation>
+    </message>
+    <message>
+        <source>Set Save Location: %1</source>
+        <translation>设置保存位置: %1</translation>
+    </message>
+    <message>
+        <source>This Will Copy Cloud as is to young cloud (caitsith&apos;s slot). Sephiroth&apos;s stats will come directly from the Default Save. Be Sure to back up your CaitSith and Vincent if you want to use them again</source>
+        <translation>年轻克劳德、萨菲罗斯占用着凯特西、文森特的角色栏，强制替换会导致数据错乱，甚至宕机。不建议修改。</translation>
+    </message>
+    <message>
+        <source>Progression Reset Complete</source>
+        <translation>进程重置完成</translation>
+    </message>
+    <message>
+        <source>&amp;Place Leader</source>
+        <translation>放置 正在操控的主角</translation>
+    </message>
+    <message>
+        <source>Place &amp;Tiny Bronco/Chocobo</source>
+        <translation>放置 小野马/陆行鸟</translation>
+    </message>
+    <message>
+        <source>Place &amp;Buggy/Highwind</source>
+        <translation>放置 越野车/疾风号</translation>
+    </message>
+    <message>
+        <source>Place &amp;Sub</source>
+        <translation>放置 潜水艇</translation>
+    </message>
+    <message>
+        <source>Place &amp;Wild Chocobo</source>
+        <translation>放置 野生陆行鸟</translation>
+    </message>
+    <message>
+        <source>Place &amp;Diamond/Ultimate/Ruby Weapon</source>
+        <translation>放置 钻石/究极/红宝石 神兵</translation>
+    </message>
+    <message>
+        <source>All Items Added</source>
+        <translation>已获得所有道具</translation>
+    </message>
+    <message>
+        <source>Turtle Paradise</source>
+        <translation>龟道乐</translation>
+    </message>
+    <message>
+        <source>KeyItem</source>
+        <translation>关键道具</translation>
+    </message>
+    <message>
+        <source>Game Region</source>
+        <translation>游戏语言区域</translation>
+    </message>
+    <message>
+        <source>US English (NTSC-U)</source>
+        <translation>US English (NTSC-U)</translation>
+    </message>
+    <message>
+        <source>UK English (PAL)</source>
+        <translation>UK English (PAL)</translation>
+    </message>
+    <message>
+        <source>French (PAL)</source>
+        <translation>French (PAL)</translation>
+    </message>
+    <message>
+        <source>German (PAL)</source>
+        <translation>German (PAL)</translation>
+    </message>
+    <message>
+        <source>Save Slot</source>
+        <translation>保存进度</translation>
+    </message>
+    <message>
+        <source>Played piano during flashback</source>
+        <translation>在回忆中弹奏了钢琴</translation>
+    </message>
+    <message>
+        <source>When Box is Partially Checked (&quot;-&quot;) it will
+trigger showing that tutorial</source>
+        <translation>当框被部分选中时 (&quot;-&quot;)，将会显示教程</translation>
+    </message>
+    <message>
+        <source>Battle Arena</source>
+        <translation>战斗广场</translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Number of wins for the &amp;quot;Special Battle&amp;quot;. Mini-Game Reward is based on number of wins.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;“特殊战斗”的胜利次数。小游戏的奖励取决于胜利次数。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <source>Special Battle Wins</source>
+        <translation>特殊战斗胜利</translation>
+    </message>
+    <message>
+        <source>New &amp;Game+ </source>
+        <translation>创建N周目继承存档</translation>
+    </message>
+    <message>
+        <source>Cleared All Items</source>
+        <translation>已清空所有道具</translation>
+    </message>
+    <message>
+        <source>Import Canceled</source>
+        <translation>导入已取消</translation>
+    </message>
+    <message>
+        <source>Error Importing Slot %1</source>
+        <translation>导入进度出错 %1</translation>
+    </message>
+</context>
+<context>
+    <name>ItemTab</name>
+    <message>
+        <source>Inventory</source>
+        <translation>背包内的道具</translation>
+    </message>
+    <message>
+        <source>Add Max of All Items</source>
+        <translation>获得所有道具，且数量最大</translation>
+    </message>
+    <message>
+        <source>Clear All Items</source>
+        <translation>清空所有道具</translation>
+    </message>
+    <message>
+        <source>Gil</source>
+        <translation>基尔</translation>
+    </message>
+    <message>
+        <source>Money</source>
+        <translation>金钱</translation>
+    </message>
+    <message>
+        <source>GP</source>
+        <translation>GP</translation>
+    </message>
+    <message>
+        <source>Battles</source>
+        <translation>战斗次数</translation>
+    </message>
+    <message>
+        <source>Search for &quot;Turtle Paradise&quot; using item search mode on the location tab</source>
+        <translation>跳转到“位置”界面，查看所有包含“龟道乐宣传单”的场景</translation>
+    </message>
+    <message>
+        <source>Turtle Paradise Flyers Collected</source>
+        <translation>龟道乐宣传单收集</translation>
+    </message>
+    <message>
+        <source>KeyItems</source>
+        <translation>关键道具</translation>
+    </message>
+    <message>
+        <source>Search For &quot;KeyItem&quot; using item search mode on the location tab</source>
+        <translation>跳转到“位置”界面，查看所有包含“关键道具”的场景</translation>
+    </message>
+    <message>
+        <source>Unused KeyItems</source>
+        <translation>未使用的关键道具</translation>
+    </message>
+    <message>
+        <source>Mystery panties</source>
+        <translation>神秘的内裤</translation>
+    </message>
+    <message>
+        <source>Letter to a Daughter</source>
+        <translation>给女儿的信</translation>
+    </message>
+    <message>
+        <source>Letter to a Wife</source>
+        <translation>给妻子的信</translation>
+    </message>
+    <message>
+        <source>Escapes</source>
+        <translation>逃跑次数</translation>
+    </message>
+</context>
+<context>
+    <name>Options</name>
+    <message>
+        <source>Select A Directory To Save FF7 PC Saves</source>
+        <translation>选择一个存放 FF7 PC 存档文件的文件夹</translation>
+    </message>
+    <message>
+        <source>Select A Directory To Save mcd/mcr saves</source>
+        <translation>选择一个存放 mcd/mcr 格式存档文件的文件夹</translation>
+    </message>
+    <message>
+        <source>Select A Directory To Load FF7 PC Saves From</source>
+        <translation>选择从哪个文件夹读取 FF7 PC 存档文件</translation>
+    </message>
+    <message>
+        <source>Select A Default Save Game (Must Be Raw PSX)</source>
+        <translation>选择一个默认的游戏存档（必须是Raw PSX）</translation>
+    </message>
+    <message>
+        <source>Select A Location To Save Character Stat Files</source>
+        <translation>选择一个存放角色状态文件的文件夹</translation>
+    </message>
+    <message>
+        <source>Options</source>
+        <translation>设置</translation>
+    </message>
+    <message>
+        <source>Default Path For Loading All Saves</source>
+        <translation>所有存档的默认文件夹路径</translation>
+    </message>
+    <message>
+        <source>Path For Emulator Memory Cards  </source>
+        <translation>模拟器记忆卡的文件夹路径</translation>
+    </message>
+    <message>
+        <source>Path For PC (.ff7) Saves</source>
+        <translation>PC版存档文件 (.ff7) 文件夹路径</translation>
+    </message>
+    <message>
+        <source>Override Builtin New Game Data</source>
+        <translation>覆盖内置的新游戏数据</translation>
+    </message>
+    <message>
+        <source>CharEditor - Advanced Mode</source>
+        <translation>角色编辑 - 进阶模式</translation>
+    </message>
+    <message>
+        <source>Chocobo Manager - Show Pcount / Personality</source>
+        <translation>陆行鸟界面 - 显示 Pcount / Personality (效果不明)</translation>
+    </message>
+    <message>
+        <source>Field Location - Show Map/X/Y/T/D</source>
+        <translation>场景位置 - 显示场景编号、X/Y/T/D坐标值</translation>
+    </message>
+    <message>
+        <source>World Map Viewer- Show int SpinBoxes for Leader ID and buggy ID</source>
+        <translation>大地图位置- 在左侧界面中显示正在操控的主角ID和越野车ID</translation>
+    </message>
+    <message>
+        <source>Game Progress - Show Untested</source>
+        <translation>游戏进程 - 显示未经测试的选项 (无意义)</translation>
+    </message>
+    <message>
+        <source>Options - Always Show Controller Mapping </source>
+        <translation>设置 - 总是显示控制器映射</translation>
+    </message>
+    <message>
+        <source>Editable Combo for Materia and Items</source>
+        <translation>魔石和道具的可编辑组合</translation>
+    </message>
+    <message>
+        <source>General</source>
+        <translation>修改器界面</translation>
+    </message>
+    <message>
+        <source>Application Language</source>
+        <translation>修改器界面语言</translation>
+    </message>
+    <message>
+        <source>Use Native File Dialogs</source>
+        <translation>使用系统默认位置 (不推荐)</translation>
+    </message>
+    <message>
+        <source>New Game Default Region </source>
+        <translation>新游戏初始存档默认区域</translation>
+    </message>
+    <message>
+        <source>NTSC-U</source>
+        <translation>NTSC-U</translation>
+    </message>
+    <message>
+        <source>PAL-E</source>
+        <translation>PAL-E</translation>
+    </message>
+    <message>
+        <source>PAL-FR</source>
+        <translation>PAL-FR</translation>
+    </message>
+    <message>
+        <source>PAL-DE</source>
+        <translation>PAL-DE</translation>
+    </message>
+    <message>
+        <source>PAL-ES</source>
+        <translation>PAL-ES</translation>
+    </message>
+    <message>
+        <source>NTSC-J</source>
+        <translation>NTSC-J</translation>
+    </message>
+    <message>
+        <source>NTSC-JI</source>
+        <translation>NTSC-JI</translation>
+    </message>
+    <message>
+        <source>Edit the Places show in sidebar on file dialogs</source>
+        <translation>编辑文件对话框侧栏中显示的位置</translation>
+    </message>
+    <message>
+        <source>Edit Places</source>
+        <translation>默认读取的文件夹路径</translation>
+    </message>
+    <message>
+        <source>Dark Theme</source>
+        <translation>深色主题</translation>
+    </message>
+    <message>
+        <source>Light Theme</source>
+        <translation>浅色主题</translation>
+    </message>
+    <message>
+        <source>Application Color Scheme</source>
+        <translation>修改器配色方案</translation>
+    </message>
+    <message>
+        <source>Raw Psx Files Only!</source>
+        <translation>仅限 Raw Psx 文件！</translation>
+    </message>
+    <message>
+        <source>Show Experimental TestData Tab</source>
+        <translation>显示“测试数据”界面 (不稳定)</translation>
+    </message>
+    <message>
+        <source>CharEditor - Simulate Leveling Up / Down</source>
+        <translation>角色编辑 - 计算数值的增减</translation>
+    </message>
+    <message>
+        <source>Reset values to defaults</source>
+        <translation>重置到初始状态</translation>
+    </message>
+    <message>
+        <source>Reset values to stored settings</source>
+        <translation>重置到上次保存的状态</translation>
+    </message>
+    <message>
+        <source>Close and save changes</source>
+        <translation>关闭并保存更改</translation>
+    </message>
+    <message>
+        <source>Close and forget changes</source>
+        <translation>关闭并放弃更改</translation>
+    </message>
+    <message>
+        <source>System Theme</source>
+        <translation>系统主题</translation>
+    </message>
+    <message>
+        <source>Application Style</source>
+        <translation>修改器界面风格</translation>
+    </message>
+    <message>
+        <source>Item Editor - Always Cap Quantity to 99</source>
+        <translation>道具编辑 - 总是将数量上限设置为99</translation>
+    </message>
+    <message>
+        <source>Fusion is the recommended theme 
+ Other themes may contain graphical issues.</source>
+        <translation>“Fusion”是推荐的界面风格主题
+其它风格主题可能会出现视觉错误</translation>
+    </message>
+    <message>
+        <source>Show Placeholders In Materia and Item Selection</source>
+        <translation>在魔石和物品选择中显示占位符（效果不明）</translation>
+    </message>
+    <message>
+        <source>Create A Backup when Overwriting a file</source>
+        <translation>在覆盖文件时创建备份</translation>
+    </message>
+    <message>
+        <source>Path For Character Stat Files And Backups</source>
+        <translation>角色状态文件与备份的文件夹路径</translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation>存档</translation>
+    </message>
+    <message>
+        <source>Paths</source>
+        <translation>存档路径</translation>
+    </message>
+    <message>
+        <source>Editing</source>
+        <translation>修改器功能</translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The Native Dialog is unable to provide filename suggestions&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;原始对话框无法提供文件名建议&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <source>TRANSLATE TO YOUR LANGUAGE NAME</source>
+        <translation>简体中文</translation>
+    </message>
+</context>
+<context>
+    <name>PartyTab</name>
+    <message>
+        <source>Party Members</source>
+        <translation>队伍成员</translation>
+    </message>
+    <message>
+        <source>Click on a Char To Edit  ===&gt;</source>
+        <translation>选择你想要修改的角色  ===&gt;</translation>
+    </message>
+    <message>
+        <source>-Empty-</source>
+        <translation>-空-</translation>
+    </message>
+    <message>
+        <source>Selected Character Max Stats/Weapons/Materia</source>
+        <translation>将所选角色的状态/武器/魔石 设置到最高等级</translation>
+    </message>
+    <message>
+        <source>Black Chocobo</source>
+        <translation>Black Chocobo 存档修改器</translation>
+    </message>
+    <message>
+        <source>Do You Want To Also Replace %1&apos;s Equipment and Materia?</source>
+        <translation>是否将 %1的装备和魔石替换为毕业套装？</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <source>Places</source>
+        <translation>位置</translation>
+    </message>
+    <message>
+        <source>Edit Places</source>
+        <translation>默认读取的文件夹路径</translation>
+    </message>
+    <message>
+        <source>Add a place</source>
+        <translation>添加一个文件夹路径</translation>
+    </message>
+    <message>
+        <source>Select a path to add to places</source>
+        <translation>选择一个要添加的文件夹路径</translation>
+    </message>
+    <message>
+        <source>Remove selected place</source>
+        <translation>移除所选的文件夹路径</translation>
+    </message>
+    <message>
+        <source>Restore default places</source>
+        <translation>恢复到默认文件夹路径</translation>
+    </message>
+    <message>
+        <source>Reset values to stored settings</source>
+        <translation>重置到上次保存的状态</translation>
+    </message>
+    <message>
+        <source>Save Changes</source>
+        <translation>保存更改</translation>
+    </message>
+    <message>
+        <source>Close</source>
+        <translation>关闭</translation>
+    </message>
+    <message>
+        <source>Adjust the play time?</source>
+        <translation>确定调整区域吗？
+（此提示对中文区玩家不重要，不必理会）</translation>
+    </message>
+    <message>
+        <source>Old region was %1hz
+New region is %2hz</source>
+        <translation>原语言区域的图像帧率标准是 %1hz
+新语言区域的图像帧率标准是 %2hz</translation>
+    </message>
+    <message>
+        <source>PAL -&gt; NTSC Conversion</source>
+        <translation>PAL -&gt; NTSC 转换</translation>
+    </message>
+    <message>
+        <source>NTSC -&gt; PAL Conversion</source>
+        <translation>NTSC -&gt; PAL 转换</translation>
+    </message>
+    <message>
+        <source>Achievement Editor</source>
+        <translation>成就编辑</translation>
+    </message>
+    <message>
+        <source>Close and save changes</source>
+        <translation>关闭并保存更改</translation>
+    </message>
+    <message>
+        <source>Close and forget changes</source>
+        <translation>关闭并放弃更改</translation>
+    </message>
+    <message>
+        <source>Failed To Save File</source>
+        <translation>保存失败</translation>
+    </message>
+    <message>
+        <source>Failed To Write File
+File:%1</source>
+        <translation>文件写入失败
+文件:%1</translation>
+    </message>
+</context>
+<context>
+    <name>UndoStack</name>
+    <message>
+        <source>Inserting %1 bytes</source>
+        <translation>嵌入 %1 bytes</translation>
+    </message>
+    <message>
+        <source>Delete %1 chars</source>
+        <translation>删除 %1 chars</translation>
+    </message>
+    <message>
+        <source>Overwrite %1 chars</source>
+        <translation>覆写 %1 chars</translation>
+    </message>
+</context>
+<context>
+    <name>errbox</name>
+    <message>
+        <source>Slot:%1
+</source>
+        <translation>进度:%1
+</translation>
+    </message>
+    <message>
+        <source>Non Final Fantasy VII Slot</source>
+        <translation>无 Final Fantasy VII 的进度</translation>
+    </message>
+    <message>
+        <source>View Anyway</source>
+        <translation>继续查看</translation>
+    </message>
+    <message>
+        <source>       Mid-Linked Block</source>
+        <translation>       中段存档位</translation>
+    </message>
+    <message>
+        <source>    Mid-Linked Block (Deleted)</source>
+        <translation>    中段存档位 (已删除)</translation>
+    </message>
+    <message>
+        <source>      End Of Linked Blocks</source>
+        <translation>      最后一个存档位</translation>
+    </message>
+    <message>
+        <source>      End Of Linked Blocks (Deleted)</source>
+        <translation>      最后一个存档位 (已删除)</translation>
+    </message>
+    <message>
+        <source>ERROR</source>
+        <translation>错误</translation>
+    </message>
+    <message numerus="yes">
+        <source>
+ Game Uses %n Save Block(s)</source>
+        <translation>
+            <numerusform>
+ Game Uses %n Save Block</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>
+   Next Data Chunk @ Slot:%1</source>
+        <translation>
+   下一个数据块 @ 进度:%1</translation>
+    </message>
+    <message>
+        <source>E&amp;xport Slot</source>
+        <translation>导出当前进度</translation>
+    </message>
+</context>
+</TS>

--- a/translations/blackchocobo_zh_TW.ts
+++ b/translations/blackchocobo_zh_TW.ts
@@ -1,0 +1,1706 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_TW">
+<context>
+    <name>About</name>
+    <message>
+        <source>About Black Chocobo</source>
+        <translation>關於 Black Chocobo 存檔修改器</translation>
+    </message>
+    <message>
+        <source>Black Chocobo </source>
+        <translation>Black Chocobo 存檔修改器</translation>
+    </message>
+    <message>
+        <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Ubuntu&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a href=&quot;http://sourceforge.net/p/blackchocobo/donate&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#508ed8;&quot;&gt;Support this Project&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Ubuntu&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a href=&quot;http://sourceforge.net/p/blackchocobo/donate&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#508ed8;&quot;&gt;支援這個專案&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <source>Translators</source>
+        <translation>翻譯人員</translation>
+    </message>
+    <message>
+        <source>Spanish Translation:</source>
+        <translation>西班牙語翻譯:</translation>
+    </message>
+    <message>
+        <source>French Translation:</source>
+        <translation>法語翻譯:</translation>
+    </message>
+    <message>
+        <source>Japanese Translation:</source>
+        <translation>日語翻譯:</translation>
+    </message>
+    <message>
+        <source>German Translation:</source>
+        <translation>德語翻譯:</translation>
+    </message>
+    <message>
+        <source>Version: %1</source>
+        <translation>版本：%1</translation>
+    </message>
+    <message>
+        <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Ubuntu&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a href=&quot;http://www.gnu.org/licenses/gpl.html&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#508ed8;&quot;&gt;License: GNU GPL Version 3&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Ubuntu&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a href=&quot;http://www.gnu.org/licenses/gpl.html&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#508ed8;&quot;&gt;許可證: GNU GPL Version 3&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <source>&amp;Close</source>
+        <translation>關閉</translation>
+    </message>
+    <message>
+        <source>ff7tk: %1</source>
+        <translation>ff7tk: %1</translation>
+    </message>
+    <message>
+        <source>Qt: %1</source>
+        <translation>Qt: %1</translation>
+    </message>
+    <message>
+        <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Ubuntu&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a href=&quot;https://github.com/sithlord48/blackchocobo&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#508ed8;&quot;&gt;Project Page&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Ubuntu&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a href=&quot;https://github.com/sithlord48/blackchocobo&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#508ed8;&quot;&gt;專案頁面&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <source>Polish Translation:</source>
+        <translation>波蘭語翻譯:</translation>
+    </message>
+    <message>
+        <source>Additonal Credits</source>
+        <translation>致謝</translation>
+    </message>
+    <message>
+        <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Ubuntu&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a href=&quot;https://github.com/sithlord48/blackchocobo/graphs/contributors&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#508ed8;&quot;&gt;Code Contributors&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Ubuntu&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a href=&quot;https://github.com/sithlord48/blackchocobo/graphs/contributors&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#508ed8;&quot;&gt;程式碼貢獻者&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <source>Icons used In this Program</source>
+        <translation>此程式使用的圖示</translation>
+    </message>
+</context>
+<context>
+    <name>BlackChocobo</name>
+    <message>
+        <source>Black Chocobo</source>
+        <translation>Black Chocobo 存檔修改器</translation>
+    </message>
+    <message>
+        <source>AP</source>
+        <translation>AP</translation>
+    </message>
+    <message>
+        <source>Party&apos;s Materia Stock</source>
+        <translation>已擁有的魔石</translation>
+    </message>
+    <message>
+        <source>Materia</source>
+        <translation>魔石</translation>
+    </message>
+    <message>
+        <source>Master</source>
+        <translation>最高等級</translation>
+    </message>
+    <message>
+        <source>Materia Stolen By Yuffie</source>
+        <translation>被尤菲偷走的魔石</translation>
+    </message>
+    <message>
+        <source>Ctrl+O</source>
+        <translation>Ctrl+O</translation>
+    </message>
+    <message>
+        <source>Time Played</source>
+        <translation>累計遊戲時間</translation>
+    </message>
+    <message>
+        <source>Sec</source>
+        <translation>秒</translation>
+    </message>
+    <message>
+        <source>Love Points</source>
+        <translation>好感度</translation>
+    </message>
+    <message>
+        <source>Selected Materia Skills and Stat Info</source>
+        <translation>所選魔石的技能與狀態資訊</translation>
+    </message>
+    <message>
+        <source>Bombing Mission Progress</source>
+        <translation>爆破任務程序</translation>
+    </message>
+    <message>
+        <source>Bombing Mission</source>
+        <translation>爆破任務</translation>
+    </message>
+    <message>
+        <source>Cloud&apos;s Flashback</source>
+        <translation>克勞德的回憶</translation>
+    </message>
+    <message>
+        <source>The Date Scene</source>
+        <translation>約會場景</translation>
+    </message>
+    <message>
+        <source>Replay Mission</source>
+        <translation>重玩任務</translation>
+    </message>
+    <message>
+        <source>         INFO ON CURRENTLY SELECTED REPLAY MISSION</source>
+        <translation>         當前選擇重玩的任務資訊</translation>
+    </message>
+    <message>
+        <source>&amp;File</source>
+        <translation>檔案</translation>
+    </message>
+    <message>
+        <source>&amp;Quit</source>
+        <translation>退出</translation>
+    </message>
+    <message>
+        <source>Open Final Fantasy 7 Save</source>
+        <translation>開啟一個FF7存檔檔案</translation>
+    </message>
+    <message>
+        <source>Cannot read file %1:
+%2.</source>
+        <translation>無法讀取檔案 %1:
+%2.</translation>
+    </message>
+    <message>
+        <source>Hour</source>
+        <translation>小時</translation>
+    </message>
+    <message>
+        <source>Min</source>
+        <translation>分鐘</translation>
+    </message>
+    <message>
+        <source>Coaster Shooter High Scores</source>
+        <translation>過山車射擊最高分</translation>
+    </message>
+    <message>
+        <source>1st</source>
+        <translation>1st</translation>
+    </message>
+    <message>
+        <source>2nd</source>
+        <translation>2nd</translation>
+    </message>
+    <message>
+        <source>3rd</source>
+        <translation>3rd</translation>
+    </message>
+    <message>
+        <source>Test Data</source>
+        <translation>測試資料</translation>
+    </message>
+    <message>
+        <source>Tutorials Seen</source>
+        <translation>已經看過教程</translation>
+    </message>
+    <message>
+        <source>Controling the Sub</source>
+        <translation>如何控制潛水艇</translation>
+    </message>
+    <message>
+        <source>Saving on the World Map</source>
+        <translation>在大地圖上存檔</translation>
+    </message>
+    <message>
+        <source>Battle Love Points</source>
+        <translation>戰鬥好感度</translation>
+    </message>
+    <message>
+        <source>Ultimate Weapons Hp</source>
+        <translation>究極神兵 剩餘HP</translation>
+    </message>
+    <message>
+        <source>Countdown Timer</source>
+        <translation>倒數計時器</translation>
+    </message>
+    <message>
+        <source>&amp;Edit</source>
+        <translation>編輯</translation>
+    </message>
+    <message>
+        <source>Select FF7 Character Stat File</source>
+        <translation>選擇FF7角色狀態檔案</translation>
+    </message>
+    <message>
+        <source>%1:
+%2 is Not a FF7 Character Stat File.</source>
+        <translation>%1:
+%2 不是FF7角色狀態檔案</translation>
+    </message>
+    <message>
+        <source>Save FF7 Character File</source>
+        <translation>儲存FF7角色狀態檔案</translation>
+    </message>
+    <message>
+        <source>FF7 Character Stat File(*.char)</source>
+        <translation>FF7角色狀態檔案 (*.char)</translation>
+    </message>
+    <message>
+        <source>===Empty Slot===</source>
+        <translation>===空===</translation>
+    </message>
+    <message>
+        <source>Highwind</source>
+        <translation>疾風號</translation>
+    </message>
+    <message>
+        <source>&amp;Open</source>
+        <translation>開啟</translation>
+    </message>
+    <message>
+        <source>&amp;Save</source>
+        <translation>儲存</translation>
+    </message>
+    <message>
+        <source>Misc</source>
+        <translation>雜項</translation>
+    </message>
+    <message>
+        <source>Party leader</source>
+        <translation>正在操控的主角</translation>
+    </message>
+    <message>
+        <source>angle</source>
+        <translation>面朝方向</translation>
+    </message>
+    <message>
+        <source>id</source>
+        <translation>id</translation>
+    </message>
+    <message>
+        <source>Tiny Bronco / Chocobo</source>
+        <translation>小野馬 / 陸行鳥</translation>
+    </message>
+    <message>
+        <source>Buggy / Highwind</source>
+        <translation>越野車 / 疾風號</translation>
+    </message>
+    <message>
+        <source>Sub</source>
+        <translation>潛艇</translation>
+    </message>
+    <message>
+        <source>sliders show </source>
+        <translation>顯示滑動條</translation>
+    </message>
+    <message>
+        <source>Party Leader</source>
+        <translation>正在操控的主角</translation>
+    </message>
+    <message>
+        <source>TinyBronco/Chocobo</source>
+        <translation>小野馬/陸行鳥</translation>
+    </message>
+    <message>
+        <source>Buggy/Highwind</source>
+        <translation>越野車/疾風號</translation>
+    </message>
+    <message>
+        <source>Wild Chocobo</source>
+        <translation>野生陸行鳥</translation>
+    </message>
+    <message>
+        <source>Diamond / Ultimate / Ruby Weapon</source>
+        <translation>鑽石 / 究極 / 紅寶石 神兵</translation>
+    </message>
+    <message>
+        <source>The Church In The Slums</source>
+        <translation>貧民窟教堂</translation>
+    </message>
+    <message>
+        <source>Aeris Death</source>
+        <translation>艾莉絲之死</translation>
+    </message>
+    <message>
+        <source>Worldmap Location</source>
+        <translation>大地圖位置</translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation>無</translation>
+    </message>
+    <message>
+        <source>Buggy</source>
+        <translation>越野車</translation>
+    </message>
+    <message>
+        <source>Replay the bombing mission from right after you get off the train.</source>
+        <translation>重玩爆破任務 (從跳下列車開始)</translation>
+    </message>
+    <message>
+        <source>Replay the death of Aeris.This option Will remove Aeris from your PHS</source>
+        <translation>重玩艾莉絲之死劇情。此選項會從PHS中移除艾莉絲。</translation>
+    </message>
+    <message>
+        <source>Meeting Aeris</source>
+        <translation>遇見艾莉絲</translation>
+    </message>
+    <message>
+        <source>Diamond / Ultimate / Ruby  Weapon</source>
+        <translation>鑽石 / 究極 / 紅寶石 神兵</translation>
+    </message>
+    <message>
+        <source>Remove ALL Materia </source>
+        <translation>移除所有魔石</translation>
+    </message>
+    <message>
+        <source>Clear All Stolen Materia</source>
+        <translation>清空所有被偷走的魔石</translation>
+    </message>
+    <message>
+        <source>-None-</source>
+        <translation>-無-</translation>
+    </message>
+    <message>
+        <source>Unknown Var:</source>
+        <translation>Unknown Var:</translation>
+    </message>
+    <message>
+        <source>#</source>
+        <translation>#</translation>
+    </message>
+    <message>
+        <source>Hex</source>
+        <translation>Hex</translation>
+    </message>
+    <message>
+        <source>Dec</source>
+        <translation>Dec</translation>
+    </message>
+    <message>
+        <source>Bin</source>
+        <translation>Bin</translation>
+    </message>
+    <message>
+        <source>Compare To Slot</source>
+        <translation>存檔進度對比</translation>
+    </message>
+    <message>
+        <source>------Right Table------&gt;
+Select A Slot To Compare
+Table is Read Only
+Var And Scrolling Synced To Left Table</source>
+        <translation>------右表格------&gt;
+選擇一個存檔進度進行比較
+表格是隻讀的
+變數和滾動同步到左表格</translation>
+    </message>
+    <message>
+        <source>Y: </source>
+        <translation>Y: </translation>
+    </message>
+    <message>
+        <source>Global Progress</source>
+        <translation>整體程序</translation>
+    </message>
+    <message>
+        <source>Main Progression</source>
+        <translation>PPV (劇情進度值)</translation>
+    </message>
+    <message>
+        <source>Elevator Door Open</source>
+        <translation>電梯門開啟</translation>
+    </message>
+    <message>
+        <source>1st Door Open</source>
+        <translation>第一個門開啟</translation>
+    </message>
+    <message>
+        <source>2nd Door Opened</source>
+        <translation>第二個門開啟了</translation>
+    </message>
+    <message>
+        <source>The Bomb Was Set</source>
+        <translation>炸彈已安裝</translation>
+    </message>
+    <message>
+        <source>Event Progress</source>
+        <translation>事件程序</translation>
+    </message>
+    <message>
+        <source>Escape From Reactor </source>
+        <translation>逃離魔晄爐</translation>
+    </message>
+    <message>
+        <source>Post Pan MD8_2</source>
+        <translation>在 MD8_2 放置了Pan</translation>
+    </message>
+    <message>
+        <source>Midgar Train Flags</source>
+        <translation>米德加列車標記</translation>
+    </message>
+    <message>
+        <source>Talked to Wedge Twice</source>
+        <translation>與威吉交談了兩次</translation>
+    </message>
+    <message>
+        <source> Played Video on Train?</source>
+        <translation>在列車上播放了影片？</translation>
+    </message>
+    <message>
+        <source>Unknowns / Unused</source>
+        <translation>未知 / 未使用</translation>
+    </message>
+    <message>
+        <source>Sector 7 Trainstation</source>
+        <translation>7號街車站</translation>
+    </message>
+    <message>
+        <source>Talked To Trainman 3 times</source>
+        <translation>與列車員交談了三次</translation>
+    </message>
+    <message>
+        <source>Pair At Station agree</source>
+        <translation>夥伴在車站同意</translation>
+    </message>
+    <message>
+        <source>Set To Reactor 5 Mode</source>
+        <translation>設定到5號魔晄爐模式</translation>
+    </message>
+    <message>
+        <source>Sector 7 Pillar</source>
+        <translation>7號街支柱</translation>
+    </message>
+    <message>
+        <source>Can Show Pillar Pan Video</source>
+        <translation>可以顯示 Pillar Pan 影片</translation>
+    </message>
+    <message>
+        <source>Barret called us</source>
+        <translation>巴雷特呼叫了大家</translation>
+    </message>
+    <message>
+        <source>Post Pillar Pan Video</source>
+        <translation>收集 Pillar Pan 影片</translation>
+    </message>
+    <message>
+        <source>Talked To soldier two times</source>
+        <translation>與神羅兵交談了兩次</translation>
+    </message>
+    <message>
+        <source>Elevator On 2nd Floor</source>
+        <translation>電梯在第二層</translation>
+    </message>
+    <message>
+        <source>Post Pan NMKIN_5</source>
+        <translation>在 NMKIN_5 放置了Pan</translation>
+    </message>
+    <message>
+        <source>Post Electrical Effect MD8_3</source>
+        <translation>在場景 MD8_3 放置電流特效</translation>
+    </message>
+    <message>
+        <source>&lt;------Left Table------
+Select Unknown Var To View
+Table Entries are Editable</source>
+        <translation>&lt;------Left Table------
+Select Unknown Var To View
+Table Entries are Editable</translation>
+    </message>
+    <message>
+        <source>Talked to Biggs</source>
+        <translation>與畢格斯交談過</translation>
+    </message>
+    <message>
+        <source>Sector 7 - Slums Progress</source>
+        <translation>7號街 - 貧民窟 程序</translation>
+    </message>
+    <message>
+        <source>Initial Settings</source>
+        <translation>初始設定</translation>
+    </message>
+    <message>
+        <source>Destroy the Sector 5 Reactor </source>
+        <translation>炸燬5號魔晄爐</translation>
+    </message>
+    <message>
+        <source>The Plate is Falling</source>
+        <translation>圓盤正在墜落</translation>
+    </message>
+    <message>
+        <source>Unsaved Changes</source>
+        <translation>未儲存的更改</translation>
+    </message>
+    <message>
+        <source>Save Changes to the File:
+%1</source>
+        <translation>將更改儲存到:
+%1</translation>
+    </message>
+    <message>
+        <source>Save Error</source>
+        <translation>儲存出錯</translation>
+    </message>
+    <message>
+        <source>Visible On World Map</source>
+        <translation>在大地圖上可見</translation>
+    </message>
+    <message>
+        <source>Tiny bronco</source>
+        <translation>小野馬</translation>
+    </message>
+    <message>
+        <source>Unknown Id in Buggy/Highwind Location</source>
+        <translation>未知的 越野車/疾風號 位置</translation>
+    </message>
+    <message>
+        <source>Wild chocobo</source>
+        <translation>野生陸行鳥</translation>
+    </message>
+    <message>
+        <source>Yellow chocobo</source>
+        <translation>陸行鳥 (黃)</translation>
+    </message>
+    <message>
+        <source>Green chocobo</source>
+        <translation>山陸行鳥 (綠)</translation>
+    </message>
+    <message>
+        <source>Blue chocobo</source>
+        <translation>川陸行鳥 (藍)</translation>
+    </message>
+    <message>
+        <source>Black chocobo</source>
+        <translation>山川陸行鳥 (黑)</translation>
+    </message>
+    <message>
+        <source>Gold chocobo</source>
+        <translation>海陸行鳥 (金)</translation>
+    </message>
+    <message>
+        <source>Load Failed</source>
+        <translation>載入失敗</translation>
+    </message>
+    <message>
+        <source>Failed to Load File</source>
+        <translation>檔案載入失敗</translation>
+    </message>
+    <message>
+        <source>Failed to save file
+%1</source>
+        <translation>檔案儲存失敗
+%1</translation>
+    </message>
+    <message>
+        <source>Can Fight Mystery Ninja in Forests</source>
+        <translation>能夠在森林中對戰神秘忍者</translation>
+    </message>
+    <message>
+        <source>Add Each Materia to Stock (end of list)</source>
+        <translation>獲得所有種類的魔石（從庫存最下列往上數）</translation>
+    </message>
+    <message>
+        <source>Beginner Course</source>
+        <translation>初級賽道</translation>
+    </message>
+    <message>
+        <source>Time:</source>
+        <translation>時間:</translation>
+    </message>
+    <message>
+        <source>:</source>
+        <translation>:</translation>
+    </message>
+    <message>
+        <source>.</source>
+        <translation>.</translation>
+    </message>
+    <message>
+        <source>Score:</source>
+        <translation>分數：</translation>
+    </message>
+    <message>
+        <source>Points</source>
+        <translation>分</translation>
+    </message>
+    <message>
+        <source>Expert Course</source>
+        <translation>高階賽道</translation>
+    </message>
+    <message>
+        <source>Crazy Course</source>
+        <translation>瘋狂賽道</translation>
+    </message>
+    <message>
+        <source>Beat Ruby Weapon</source>
+        <translation>擊敗紅寶石神兵</translation>
+    </message>
+    <message>
+        <source>Beat Emerald Weapon</source>
+        <translation>擊敗綠寶石神兵</translation>
+    </message>
+    <message>
+        <source>Battle Points</source>
+        <translation>戰鬥點數</translation>
+    </message>
+    <message>
+        <source>Hex Editor</source>
+        <translation>Hex 編輯器</translation>
+    </message>
+    <message>
+        <source>Show:</source>
+        <translation>顯示:</translation>
+    </message>
+    <message>
+        <source>Unknown Vars</source>
+        <translation>Unknown Vars</translation>
+    </message>
+    <message>
+        <source>Replay the Date Scene, Your Location will be set To The Ropeway Station Talk to man by the Tram to start event. If Your Looking for a special Date be sure to set your love points too.</source>
+        <translation>重玩約會場景，你的位置將被設定到觀光纜車站。在進行約會之前，別忘了修改你想要約會的角色的好感度。</translation>
+    </message>
+    <message>
+        <source>PSX Save Data</source>
+        <translation>PSX 存檔資料</translation>
+    </message>
+    <message>
+        <source>Game Options</source>
+        <translation>遊戲內設定</translation>
+    </message>
+    <message>
+        <source>Character Export Successful</source>
+        <translation>角色狀態檔案匯入成功</translation>
+    </message>
+    <message>
+        <source>Character Export Failed</source>
+        <translation>角色狀態檔案匯入失敗</translation>
+    </message>
+    <message>
+        <source>Export Successful</source>
+        <translation>匯出成功</translation>
+    </message>
+    <message>
+        <source>Export Failed</source>
+        <translation>匯出失敗</translation>
+    </message>
+    <message>
+        <source>Fort Condor</source>
+        <translation>禿鷲要塞</translation>
+    </message>
+    <message>
+        <source>Funds </source>
+        <translation>資金</translation>
+    </message>
+    <message>
+        <source>Record </source>
+        <translation>記錄</translation>
+    </message>
+    <message>
+        <source>/</source>
+        <translation>/</translation>
+    </message>
+    <message>
+        <source>Bombing Mission Start Flag</source>
+        <translation>爆破任務開始標記</translation>
+    </message>
+    <message>
+        <source>Builtin Data</source>
+        <translation>內部資料</translation>
+    </message>
+    <message>
+        <source>New Game Created - Using: %1</source>
+        <translation>新遊戲初始存檔已建立 - 正在使用: %1 (清空所有角色練度、道具、魔石，重新開始新遊戲)</translation>
+    </message>
+    <message>
+        <source>New Game Plus Created - Using: %1</source>
+        <translation>N周目繼承存檔已建立 - 正在使用: %1 (角色練度、道具、魔石繼承到新遊戲初始進度)</translation>
+    </message>
+    <message>
+        <source>Have Seen Pandora&apos;s Box</source>
+        <translation>已看過潘多拉魔盒技能</translation>
+    </message>
+    <message>
+        <source>Imported Slot:%2 from %1 -&gt; Slot:%3</source>
+        <translation>將 %1 中的進度:%2 匯入到進度:%3</translation>
+    </message>
+    <message>
+        <source>&amp;Copy Current Slot</source>
+        <translation>複製當前的進度</translation>
+    </message>
+    <message>
+        <source>&amp;Paste Slot</source>
+        <translation>貼上已複製的進度</translation>
+    </message>
+    <message>
+        <source>Clea&amp;r Slot</source>
+        <translation>刪除當前進度</translation>
+    </message>
+    <message>
+        <source>&amp;New Game</source>
+        <translation>建立新遊戲初始存檔</translation>
+    </message>
+    <message>
+        <source>E&amp;xport Current Character</source>
+        <translation>匯出當前角色狀態</translation>
+    </message>
+    <message>
+        <source>I&amp;mport Current Character</source>
+        <translation>匯入角色狀態檔案</translation>
+    </message>
+    <message>
+        <source>DonProgress</source>
+        <translation>DonProgress</translation>
+    </message>
+    <message>
+        <source>&amp;Import To Current Slot</source>
+        <translation>選擇其它存檔的單個進度 替換當前進度</translation>
+    </message>
+    <message>
+        <source>Party</source>
+        <translation>隊伍</translation>
+    </message>
+    <message>
+        <source>Items</source>
+        <translation>道具</translation>
+    </message>
+    <message>
+        <source>Location</source>
+        <translation>主角所在位置</translation>
+    </message>
+    <message>
+        <source>Field Location</source>
+        <translation>場景位置</translation>
+    </message>
+    <message>
+        <source>Right click on map to easily set an item&apos;s
+location.</source>
+        <translation>右鍵單擊地圖，放置道具。</translation>
+    </message>
+    <message>
+        <source>Game Progress</source>
+        <translation>遊戲程序</translation>
+    </message>
+    <message>
+        <source>Disc  #</source>
+        <translation>光碟  #</translation>
+    </message>
+    <message>
+        <source>Jessie Has Been Unstuck</source>
+        <translation>傑西已經擺脫困境</translation>
+    </message>
+    <message>
+        <source>Trigger Game Over (countdown reached 0)</source>
+        <translation>觸發遊戲結束 (倒計時到達 0)</translation>
+    </message>
+    <message>
+        <source>Talked to Jessie Before Looking At Map</source>
+        <translation>在觀看地圖前與傑西交談過</translation>
+    </message>
+    <message>
+        <source>Avalanche had meeting after Bombing Mission</source>
+        <translation>雪崩在爆破任務後會合</translation>
+    </message>
+    <message>
+        <source>Avalanche Has Run To Hideout</source>
+        <translation>雪崩前往了藏身處</translation>
+    </message>
+    <message>
+        <source>ChurchProgress</source>
+        <translation>教堂程序</translation>
+    </message>
+    <message>
+        <source>Set Replay Mission below to set the game back to that mission. This will automatically set your save location and disc # as well as Quest Progression vars. DO NOT OVERWRITE YOUR CURRENT SAVE when using this feature; I cannot promise that you will be able to play from any replay until the end of the game, or that any given replay will work in your save. This feature is still under development.</source>
+        <translation>“重玩任務”是開發中的功能，不建議使用。</translation>
+    </message>
+    <message>
+        <source>Apply Selected Replay </source>
+        <translation>應用所選任務</translation>
+    </message>
+    <message>
+        <source>Other</source>
+        <translation>其它</translation>
+    </message>
+    <message>
+        <source>Unlocked Vincent</source>
+        <translation>文森特已入隊</translation>
+    </message>
+    <message>
+        <source>Unlocked Yuffie </source>
+        <translation>尤菲已入隊</translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Resets
+When you Pass thru Battle Square&apos;s Door Set Location To &amp;quot;Arena
+Lobby&amp;quot; so you can spend
+them&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;當你透過戰鬥過場的門，重新進入鬥技場大廳之後，才可以使用修改過的戰鬥點數(BP)。(不確定是否有效)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <source>Number of Steps</source>
+        <translation>步數</translation>
+    </message>
+    <message>
+        <source>Cait Sith and Vincent should not be enabled if they are disabled in the Party tab.</source>
+        <translation>如果凱特西、文森特不在隊伍中，請不要勾選他們的選項</translation>
+    </message>
+    <message>
+        <source>Snowboard Mini Game </source>
+        <translation>滑雪小遊戲</translation>
+    </message>
+    <message>
+        <source>G-Bike High Score</source>
+        <translation>G-Bike 最高分</translation>
+    </message>
+    <message>
+        <source>Have Won the Submarine Game</source>
+        <translation>潛艇遊戲已獲勝</translation>
+    </message>
+    <message>
+        <source>Playstation Save Info</source>
+        <translation>PlayStation 存檔資訊</translation>
+    </message>
+    <message>
+        <source>PsxName:</source>
+        <translation>Psx名稱:</translation>
+    </message>
+    <message>
+        <source>No Description Text</source>
+        <translation>無描述文字</translation>
+    </message>
+    <message>
+        <source>Save Point Location In North Crater</source>
+        <translation>記錄點位置在大空洞</translation>
+    </message>
+    <message>
+        <source>Map Id: </source>
+        <translation>地圖ID: </translation>
+    </message>
+    <message>
+        <source>X: </source>
+        <translation>X: </translation>
+    </message>
+    <message>
+        <source>Z:</source>
+        <translation>Z:</translation>
+    </message>
+    <message>
+        <source>He&amp;lp</source>
+        <translation>幫助</translation>
+    </message>
+    <message>
+        <source>&amp;View</source>
+        <translation>進度切換</translation>
+    </message>
+    <message>
+        <source>&amp;Settings</source>
+        <translation>修改器設定</translation>
+    </message>
+    <message>
+        <source>&amp;Slot Region</source>
+        <translation>更改進度的區域 (不同平臺存檔轉換)</translation>
+    </message>
+    <message>
+        <source>Ctrl+Q</source>
+        <translation>Ctrl+Q</translation>
+    </message>
+    <message>
+        <source>Sa&amp;ve As</source>
+        <translation>另存為</translation>
+    </message>
+    <message>
+        <source>Ctrl+Shift+S</source>
+        <translation>Ctrl+Shift+S</translation>
+    </message>
+    <message>
+        <source>&amp;About</source>
+        <translation>關於</translation>
+    </message>
+    <message>
+        <source>&amp;Select Slot</source>
+        <translation>選擇其它進度</translation>
+    </message>
+    <message>
+        <source>F4</source>
+        <translation>F4</translation>
+    </message>
+    <message>
+        <source>Ctrl+Shift+C</source>
+        <translation>Ctrl+Shift+C</translation>
+    </message>
+    <message>
+        <source>Ctrl+Shift+V</source>
+        <translation>Ctrl+Shift+V</translation>
+    </message>
+    <message>
+        <source>Ctrl+Shift+Del</source>
+        <translation>Ctrl+Shift+Del</translation>
+    </message>
+    <message>
+        <source>&amp;Previous Slot</source>
+        <translation>當前存檔的上一個進度</translation>
+    </message>
+    <message>
+        <source>Alt+Left</source>
+        <translation>Alt+Left</translation>
+    </message>
+    <message>
+        <source>&amp;Next Slot</source>
+        <translation>當前存檔的下一個進度</translation>
+    </message>
+    <message>
+        <source>Alt+Right</source>
+        <translation>Alt+Right</translation>
+    </message>
+    <message>
+        <source>&amp;Configure</source>
+        <translation>自定義</translation>
+    </message>
+    <message>
+        <source>Application Preferences</source>
+        <translation>修改器首選項</translation>
+    </message>
+    <message>
+        <source>F2</source>
+        <translation>F2</translation>
+    </message>
+    <message>
+        <source>&amp;Us English (NTSC-U)</source>
+        <translation>&amp;Us English (NTSC-U)</translation>
+    </message>
+    <message>
+        <source>Uk &amp;English (PAL)</source>
+        <translation>Uk &amp;English (PAL)</translation>
+    </message>
+    <message>
+        <source>&amp;German (PAL)</source>
+        <translation>&amp;German (PAL)</translation>
+    </message>
+    <message>
+        <source>&amp;Spanish (PAL)</source>
+        <translation>&amp;Spanish (PAL)</translation>
+    </message>
+    <message>
+        <source>Spanish (PAL)</source>
+        <translation>Spanish (PAL)</translation>
+    </message>
+    <message>
+        <source>&amp;Japanese (NTSC-J)</source>
+        <translation>&amp;Japanese (NTSC-J)</translation>
+    </message>
+    <message>
+        <source>Japanese (NTSC-J)</source>
+        <translation>Japanese (NTSC-J)</translation>
+    </message>
+    <message>
+        <source>&amp;International (NTSC-J)</source>
+        <translation>&amp;International (NTSC-J)</translation>
+    </message>
+    <message>
+        <source>International (NTSC-J)</source>
+        <translation>International (NTSC-J)</translation>
+    </message>
+    <message>
+        <source>Ctrl+Shift+N</source>
+        <translation>Ctrl+Shift+N</translation>
+    </message>
+    <message>
+        <source>Ctrl+Shift+=</source>
+        <translation>Ctrl+Shift+=</translation>
+    </message>
+    <message>
+        <source>Ctrl+E</source>
+        <translation>Ctrl+E</translation>
+    </message>
+    <message>
+        <source>Ctrl+Ins</source>
+        <translation>Ctrl+Ins</translation>
+    </message>
+    <message>
+        <source>&amp;Reload</source>
+        <translation>重新載入</translation>
+    </message>
+    <message>
+        <source>&amp;French (PAL)</source>
+        <translation>&amp;French (PAL)</translation>
+    </message>
+    <message>
+        <source>Create Cloud Save &amp;Folder</source>
+        <translation>建立雲存檔 以及資料夾</translation>
+    </message>
+    <message>
+        <source>F9</source>
+        <translation>F9</translation>
+    </message>
+    <message>
+        <source>Ctrl+Shift+Ins</source>
+        <translation>Ctrl+Shift+Ins</translation>
+    </message>
+    <message>
+        <source>&amp;Achievement Editor</source>
+        <translation>成就編輯</translation>
+    </message>
+    <message>
+        <source>F10</source>
+        <translation>F10</translation>
+    </message>
+    <message>
+        <source>Chocobo</source>
+        <translation>陸行鳥</translation>
+    </message>
+    <message>
+        <source>Slot</source>
+        <translation>進度</translation>
+    </message>
+    <message>
+        <source>Imported %1 -&gt; Slot:%2</source>
+        <translation>將 %1 匯入到進度:%2</translation>
+    </message>
+    <message>
+        <source>Error Loading File %1</source>
+        <translation>載入檔案失敗 %1</translation>
+    </message>
+    <message>
+        <source>Select A File to Save As</source>
+        <translation>選擇另存為哪個檔案</translation>
+    </message>
+    <message>
+        <source>Select Achievement File</source>
+        <translation>選擇成就記錄檔案 (achievement.dat)</translation>
+    </message>
+    <message>
+        <source>Dat File (*.dat)</source>
+        <translation>Dat 檔案 (*.dat)</translation>
+    </message>
+    <message>
+        <source>Current Slot:%1</source>
+        <translation>當前進度:%1</translation>
+    </message>
+    <message>
+        <source>Exported Slot:%2 from %1 -&gt; %3</source>
+        <translation>將進度:%2 從 %1 匯出到 %3</translation>
+    </message>
+    <message>
+        <source>
+ Mid-Linked Block </source>
+        <translation>
+ 中段存檔位 </translation>
+    </message>
+    <message>
+        <source>
+ End Of Linked Data</source>
+        <translation>
+最後一個關聯資料</translation>
+    </message>
+    <message>
+        <source>(Deleted)</source>
+        <translation>(已刪除)</translation>
+    </message>
+    <message numerus="yes">
+        <source>Game Uses %n Save Block(s)</source>
+        <translation>
+            <numerusform>遊戲使用 %n 存檔位</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>
+  Next Data Chunk @ Slot:%1</source>
+        <translation>
+  下一個資料塊 @ 進度:%1</translation>
+    </message>
+    <message>
+        <source>All Materia Added!</source>
+        <translation>已獲得所有種類的魔石！</translation>
+    </message>
+    <message>
+        <source>Set Save Location: %1</source>
+        <translation>設定儲存位置: %1</translation>
+    </message>
+    <message>
+        <source>This Will Copy Cloud as is to young cloud (caitsith&apos;s slot). Sephiroth&apos;s stats will come directly from the Default Save. Be Sure to back up your CaitSith and Vincent if you want to use them again</source>
+        <translation>年輕克勞德、賽菲羅斯佔用著凱特西、文森特的角色欄，強制替換會導致資料錯亂，甚至宕機。不建議修改。</translation>
+    </message>
+    <message>
+        <source>Progression Reset Complete</source>
+        <translation>程序重置完成</translation>
+    </message>
+    <message>
+        <source>&amp;Place Leader</source>
+        <translation>放置 正在操控的主角</translation>
+    </message>
+    <message>
+        <source>Place &amp;Tiny Bronco/Chocobo</source>
+        <translation>放置 小野馬/陸行鳥</translation>
+    </message>
+    <message>
+        <source>Place &amp;Buggy/Highwind</source>
+        <translation>放置 越野車/疾風號</translation>
+    </message>
+    <message>
+        <source>Place &amp;Sub</source>
+        <translation>放置 潛水艇</translation>
+    </message>
+    <message>
+        <source>Place &amp;Wild Chocobo</source>
+        <translation>放置 野生陸行鳥</translation>
+    </message>
+    <message>
+        <source>Place &amp;Diamond/Ultimate/Ruby Weapon</source>
+        <translation>放置 鑽石/究極/紅寶石 神兵</translation>
+    </message>
+    <message>
+        <source>All Items Added</source>
+        <translation>已獲得所有道具</translation>
+    </message>
+    <message>
+        <source>Turtle Paradise</source>
+        <translation>龜道樂</translation>
+    </message>
+    <message>
+        <source>KeyItem</source>
+        <translation>關鍵道具</translation>
+    </message>
+    <message>
+        <source>Game Region</source>
+        <translation>遊戲語言區域</translation>
+    </message>
+    <message>
+        <source>US English (NTSC-U)</source>
+        <translation>US English (NTSC-U)</translation>
+    </message>
+    <message>
+        <source>UK English (PAL)</source>
+        <translation>UK English (PAL)</translation>
+    </message>
+    <message>
+        <source>French (PAL)</source>
+        <translation>French (PAL)</translation>
+    </message>
+    <message>
+        <source>German (PAL)</source>
+        <translation>German (PAL)</translation>
+    </message>
+    <message>
+        <source>Save Slot</source>
+        <translation>儲存進度</translation>
+    </message>
+    <message>
+        <source>Played piano during flashback</source>
+        <translation>在回憶中彈奏了鋼琴</translation>
+    </message>
+    <message>
+        <source>When Box is Partially Checked (&quot;-&quot;) it will
+trigger showing that tutorial</source>
+        <translation>當框被部分選中時 (&quot;-&quot;)，將會顯示教程</translation>
+    </message>
+    <message>
+        <source>Battle Arena</source>
+        <translation>戰鬥廣場</translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Number of wins for the &amp;quot;Special Battle&amp;quot;. Mini-Game Reward is based on number of wins.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;“特殊戰鬥”的勝利次數。小遊戲的獎勵取決於勝利次數。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <source>Special Battle Wins</source>
+        <translation>特殊戰鬥勝利</translation>
+    </message>
+    <message>
+        <source>New &amp;Game+ </source>
+        <translation>建立N周目繼承存檔</translation>
+    </message>
+    <message>
+        <source>Cleared All Items</source>
+        <translation>已清空所有道具</translation>
+    </message>
+    <message>
+        <source>Import Canceled</source>
+        <translation>匯入已取消</translation>
+    </message>
+    <message>
+        <source>Error Importing Slot %1</source>
+        <translation>匯入進度出錯 %1</translation>
+    </message>
+</context>
+<context>
+    <name>ItemTab</name>
+    <message>
+        <source>Inventory</source>
+        <translation>揹包內的道具</translation>
+    </message>
+    <message>
+        <source>Add Max of All Items</source>
+        <translation>獲得所有道具，且數量最大</translation>
+    </message>
+    <message>
+        <source>Clear All Items</source>
+        <translation>清空所有道具</translation>
+    </message>
+    <message>
+        <source>Gil</source>
+        <translation>基爾</translation>
+    </message>
+    <message>
+        <source>Money</source>
+        <translation>金錢</translation>
+    </message>
+    <message>
+        <source>GP</source>
+        <translation>GP</translation>
+    </message>
+    <message>
+        <source>Battles</source>
+        <translation>戰鬥次數</translation>
+    </message>
+    <message>
+        <source>Search for &quot;Turtle Paradise&quot; using item search mode on the location tab</source>
+        <translation>跳轉到“位置”介面，檢視所有包含“龜道樂宣傳單”的場景</translation>
+    </message>
+    <message>
+        <source>Turtle Paradise Flyers Collected</source>
+        <translation>龜道樂宣傳單收集</translation>
+    </message>
+    <message>
+        <source>KeyItems</source>
+        <translation>關鍵道具</translation>
+    </message>
+    <message>
+        <source>Search For &quot;KeyItem&quot; using item search mode on the location tab</source>
+        <translation>跳轉到“位置”介面，檢視所有包含“關鍵道具”的場景</translation>
+    </message>
+    <message>
+        <source>Unused KeyItems</source>
+        <translation>未使用的關鍵道具</translation>
+    </message>
+    <message>
+        <source>Mystery panties</source>
+        <translation>神秘的內褲</translation>
+    </message>
+    <message>
+        <source>Letter to a Daughter</source>
+        <translation>給女兒的信</translation>
+    </message>
+    <message>
+        <source>Letter to a Wife</source>
+        <translation>給妻子的信</translation>
+    </message>
+    <message>
+        <source>Escapes</source>
+        <translation>逃跑次數</translation>
+    </message>
+</context>
+<context>
+    <name>Options</name>
+    <message>
+        <source>Select A Directory To Save FF7 PC Saves</source>
+        <translation>選擇一個存放 FF7 PC 存檔檔案的資料夾</translation>
+    </message>
+    <message>
+        <source>Select A Directory To Save mcd/mcr saves</source>
+        <translation>選擇一個存放 mcd/mcr 格式存檔檔案的資料夾</translation>
+    </message>
+    <message>
+        <source>Select A Directory To Load FF7 PC Saves From</source>
+        <translation>選擇從哪個資料夾讀取 FF7 PC 存檔檔案</translation>
+    </message>
+    <message>
+        <source>Select A Default Save Game (Must Be Raw PSX)</source>
+        <translation>選擇一個預設的遊戲存檔（必須是Raw PSX）</translation>
+    </message>
+    <message>
+        <source>Select A Location To Save Character Stat Files</source>
+        <translation>選擇一個存放角色狀態檔案的資料夾</translation>
+    </message>
+    <message>
+        <source>Options</source>
+        <translation>設定</translation>
+    </message>
+    <message>
+        <source>Default Path For Loading All Saves</source>
+        <translation>所有存檔的預設資料夾路徑</translation>
+    </message>
+    <message>
+        <source>Path For Emulator Memory Cards  </source>
+        <translation>模擬器記憶卡的資料夾路徑</translation>
+    </message>
+    <message>
+        <source>Path For PC (.ff7) Saves</source>
+        <translation>PC版存檔檔案 (.ff7) 資料夾路徑</translation>
+    </message>
+    <message>
+        <source>Override Builtin New Game Data</source>
+        <translation>覆蓋內建的新遊戲資料</translation>
+    </message>
+    <message>
+        <source>CharEditor - Advanced Mode</source>
+        <translation>角色編輯 - 進階模式</translation>
+    </message>
+    <message>
+        <source>Chocobo Manager - Show Pcount / Personality</source>
+        <translation>陸行鳥介面 - 顯示 Pcount / Personality (效果不明)</translation>
+    </message>
+    <message>
+        <source>Field Location - Show Map/X/Y/T/D</source>
+        <translation>場景位置 - 顯示場景編號、X/Y/T/D座標值</translation>
+    </message>
+    <message>
+        <source>World Map Viewer- Show int SpinBoxes for Leader ID and buggy ID</source>
+        <translation>大地圖位置- 在左側介面中顯示正在操控的主角ID和越野車ID</translation>
+    </message>
+    <message>
+        <source>Game Progress - Show Untested</source>
+        <translation>遊戲程序 - 顯示未經測試的選項 (無意義)</translation>
+    </message>
+    <message>
+        <source>Options - Always Show Controller Mapping </source>
+        <translation>設定 - 總是顯示控制器對映</translation>
+    </message>
+    <message>
+        <source>Editable Combo for Materia and Items</source>
+        <translation>魔石和道具的可編輯組合</translation>
+    </message>
+    <message>
+        <source>General</source>
+        <translation>修改器介面</translation>
+    </message>
+    <message>
+        <source>Application Language</source>
+        <translation>修改器介面語言</translation>
+    </message>
+    <message>
+        <source>Use Native File Dialogs</source>
+        <translation>使用系統預設位置 (不推薦)</translation>
+    </message>
+    <message>
+        <source>New Game Default Region </source>
+        <translation>新遊戲初始存檔預設區域</translation>
+    </message>
+    <message>
+        <source>NTSC-U</source>
+        <translation>NTSC-U</translation>
+    </message>
+    <message>
+        <source>PAL-E</source>
+        <translation>PAL-E</translation>
+    </message>
+    <message>
+        <source>PAL-FR</source>
+        <translation>PAL-FR</translation>
+    </message>
+    <message>
+        <source>PAL-DE</source>
+        <translation>PAL-DE</translation>
+    </message>
+    <message>
+        <source>PAL-ES</source>
+        <translation>PAL-ES</translation>
+    </message>
+    <message>
+        <source>NTSC-J</source>
+        <translation>NTSC-J</translation>
+    </message>
+    <message>
+        <source>NTSC-JI</source>
+        <translation>NTSC-JI</translation>
+    </message>
+    <message>
+        <source>Edit the Places show in sidebar on file dialogs</source>
+        <translation>編輯檔案對話方塊側欄中顯示的位置</translation>
+    </message>
+    <message>
+        <source>Edit Places</source>
+        <translation>預設讀取的資料夾路徑</translation>
+    </message>
+    <message>
+        <source>Dark Theme</source>
+        <translation>深色主題</translation>
+    </message>
+    <message>
+        <source>Light Theme</source>
+        <translation>淺色主題</translation>
+    </message>
+    <message>
+        <source>Application Color Scheme</source>
+        <translation>修改器配色方案</translation>
+    </message>
+    <message>
+        <source>Raw Psx Files Only!</source>
+        <translation>僅限 Raw Psx 檔案！</translation>
+    </message>
+    <message>
+        <source>Show Experimental TestData Tab</source>
+        <translation>顯示“測試資料”介面 (不穩定)</translation>
+    </message>
+    <message>
+        <source>CharEditor - Simulate Leveling Up / Down</source>
+        <translation>角色編輯 - 計算數值的增減</translation>
+    </message>
+    <message>
+        <source>Reset values to defaults</source>
+        <translation>重置到初始狀態</translation>
+    </message>
+    <message>
+        <source>Reset values to stored settings</source>
+        <translation>重置到上次儲存的狀態</translation>
+    </message>
+    <message>
+        <source>Close and save changes</source>
+        <translation>關閉並儲存更改</translation>
+    </message>
+    <message>
+        <source>Close and forget changes</source>
+        <translation>關閉並放棄更改</translation>
+    </message>
+    <message>
+        <source>System Theme</source>
+        <translation>系統主題</translation>
+    </message>
+    <message>
+        <source>Application Style</source>
+        <translation>修改器介面風格</translation>
+    </message>
+    <message>
+        <source>Item Editor - Always Cap Quantity to 99</source>
+        <translation>道具編輯 - 總是將數量上限設定為99</translation>
+    </message>
+    <message>
+        <source>Fusion is the recommended theme 
+ Other themes may contain graphical issues.</source>
+        <translation>“Fusion”是推薦的介面風格主題
+其它風格主題可能會出現視覺錯誤</translation>
+    </message>
+    <message>
+        <source>Show Placeholders In Materia and Item Selection</source>
+        <translation>在魔石和物品選擇中顯示佔位符（效果不明）</translation>
+    </message>
+    <message>
+        <source>Create A Backup when Overwriting a file</source>
+        <translation>在覆蓋檔案時建立備份</translation>
+    </message>
+    <message>
+        <source>Path For Character Stat Files And Backups</source>
+        <translation>角色狀態檔案與備份的資料夾路徑</translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation>存檔</translation>
+    </message>
+    <message>
+        <source>Paths</source>
+        <translation>存檔路徑</translation>
+    </message>
+    <message>
+        <source>Editing</source>
+        <translation>修改器功能</translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The Native Dialog is unable to provide filename suggestions&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;原始對話方塊無法提供檔名建議&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <source>TRANSLATE TO YOUR LANGUAGE NAME</source>
+        <translation>簡體中文</translation>
+    </message>
+</context>
+<context>
+    <name>PartyTab</name>
+    <message>
+        <source>Party Members</source>
+        <translation>隊伍成員</translation>
+    </message>
+    <message>
+        <source>Click on a Char To Edit  ===&gt;</source>
+        <translation>選擇你想要修改的角色  ===&gt;</translation>
+    </message>
+    <message>
+        <source>-Empty-</source>
+        <translation>-空-</translation>
+    </message>
+    <message>
+        <source>Selected Character Max Stats/Weapons/Materia</source>
+        <translation>將所選角色的狀態/武器/魔石 設定到最高等級</translation>
+    </message>
+    <message>
+        <source>Black Chocobo</source>
+        <translation>Black Chocobo 存檔修改器</translation>
+    </message>
+    <message>
+        <source>Do You Want To Also Replace %1&apos;s Equipment and Materia?</source>
+        <translation>是否將 %1的裝備和魔石替換為畢業套裝？</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <source>Places</source>
+        <translation>位置</translation>
+    </message>
+    <message>
+        <source>Edit Places</source>
+        <translation>預設讀取的資料夾路徑</translation>
+    </message>
+    <message>
+        <source>Add a place</source>
+        <translation>新增一個資料夾路徑</translation>
+    </message>
+    <message>
+        <source>Select a path to add to places</source>
+        <translation>選擇一個要新增的資料夾路徑</translation>
+    </message>
+    <message>
+        <source>Remove selected place</source>
+        <translation>移除所選的資料夾路徑</translation>
+    </message>
+    <message>
+        <source>Restore default places</source>
+        <translation>恢復到預設資料夾路徑</translation>
+    </message>
+    <message>
+        <source>Reset values to stored settings</source>
+        <translation>重置到上次儲存的狀態</translation>
+    </message>
+    <message>
+        <source>Save Changes</source>
+        <translation>儲存更改</translation>
+    </message>
+    <message>
+        <source>Close</source>
+        <translation>關閉</translation>
+    </message>
+    <message>
+        <source>Adjust the play time?</source>
+        <translation>確定調整區域嗎？
+（此提示對中文區玩家不重要，不必理會）</translation>
+    </message>
+    <message>
+        <source>Old region was %1hz
+New region is %2hz</source>
+        <translation>原語言區域的影象幀率標準是 %1hz
+新語言區域的影象幀率標準是 %2hz</translation>
+    </message>
+    <message>
+        <source>PAL -&gt; NTSC Conversion</source>
+        <translation>PAL -&gt; NTSC 轉換</translation>
+    </message>
+    <message>
+        <source>NTSC -&gt; PAL Conversion</source>
+        <translation>NTSC -&gt; PAL 轉換</translation>
+    </message>
+    <message>
+        <source>Achievement Editor</source>
+        <translation>成就編輯</translation>
+    </message>
+    <message>
+        <source>Close and save changes</source>
+        <translation>關閉並儲存更改</translation>
+    </message>
+    <message>
+        <source>Close and forget changes</source>
+        <translation>關閉並放棄更改</translation>
+    </message>
+    <message>
+        <source>Failed To Save File</source>
+        <translation>儲存失敗</translation>
+    </message>
+    <message>
+        <source>Failed To Write File
+File:%1</source>
+        <translation>檔案寫入失敗
+檔案:%1</translation>
+    </message>
+</context>
+<context>
+    <name>UndoStack</name>
+    <message>
+        <source>Inserting %1 bytes</source>
+        <translation>嵌入 %1 bytes</translation>
+    </message>
+    <message>
+        <source>Delete %1 chars</source>
+        <translation>刪除 %1 chars</translation>
+    </message>
+    <message>
+        <source>Overwrite %1 chars</source>
+        <translation>覆寫 %1 chars</translation>
+    </message>
+</context>
+<context>
+    <name>errbox</name>
+    <message>
+        <source>Slot:%1
+</source>
+        <translation>進度:%1
+</translation>
+    </message>
+    <message>
+        <source>Non Final Fantasy VII Slot</source>
+        <translation>無 Final Fantasy VII 的進度</translation>
+    </message>
+    <message>
+        <source>View Anyway</source>
+        <translation>繼續檢視</translation>
+    </message>
+    <message>
+        <source>       Mid-Linked Block</source>
+        <translation>       中段存檔位</translation>
+    </message>
+    <message>
+        <source>    Mid-Linked Block (Deleted)</source>
+        <translation>    中段存檔位 (已刪除)</translation>
+    </message>
+    <message>
+        <source>      End Of Linked Blocks</source>
+        <translation>      最後一個存檔位</translation>
+    </message>
+    <message>
+        <source>      End Of Linked Blocks (Deleted)</source>
+        <translation>      最後一個存檔位 (已刪除)</translation>
+    </message>
+    <message>
+        <source>ERROR</source>
+        <translation>錯誤</translation>
+    </message>
+    <message numerus="yes">
+        <source>
+ Game Uses %n Save Block(s)</source>
+        <translation>
+            <numerusform>
+ Game Uses %n Save Block</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>
+   Next Data Chunk @ Slot:%1</source>
+        <translation>
+   下一個資料塊 @ 進度:%1</translation>
+    </message>
+    <message>
+        <source>E&amp;xport Slot</source>
+        <translation>匯出當前進度</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
FF7 FFSky ver.3 is an unofficial Chinese version produced by the FFSky team. It is also the only Chinese translation of FF7 PC in China since 2005.

Our translation is based on FF7 original Japanese version. All the nouns are translated from Japanese to Chinese by professional translators.

This submission includes the simplified Chinese and traditional Chinese translations for Black Chocobo's application interface.

Chinese translator: Tekkaman
Proofreader and programmer: RandySeptem